### PR TITLE
Add Open in molab badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/kihaji/deckgl-marimo/blob/main/examples/hexagon_example.py)
+
 # deckgl-marimo
 
 deck.gl HexagonLayer widget for marimo notebooks via anywidget.


### PR DESCRIPTION
Nice project! 

With this button in the readme, folks can immediately toy around with the demo. If you update the notebook in Github we will automatically update on our end as well :) 

Any objections if we add your demo notebook to our gallery? 