### PR TITLE
JS deps: deck.gl 9.3.6 tilde-pinned, maplibre ~5.24.0, esbuild ^0.28.1

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -8,25 +8,28 @@
       "name": "deckgl-marimo-js",
       "version": "0.6.1",
       "dependencies": {
-        "@deck.gl/aggregation-layers": "^9.3.1",
-        "@deck.gl/core": "^9.3.1",
-        "@deck.gl/geo-layers": "^9.3.1",
-        "@deck.gl/layers": "^9.3.1",
-        "@deck.gl/mapbox": "^9.3.1",
-        "@deck.gl/mesh-layers": "^9.3.1",
-        "maplibre-gl": "^5.24.0"
+        "@deck.gl/aggregation-layers": "~9.3.6",
+        "@deck.gl/core": "~9.3.6",
+        "@deck.gl/geo-layers": "~9.3.6",
+        "@deck.gl/layers": "~9.3.6",
+        "@deck.gl/mapbox": "~9.3.6",
+        "@deck.gl/mesh-layers": "~9.3.6",
+        "maplibre-gl": "~5.24.0"
       },
       "devDependencies": {
-        "esbuild": "^0.24.0"
+        "esbuild": "^0.28.1"
+      },
+      "engines": {
+        "node": ">=20.9"
       }
     },
     "node_modules/@deck.gl/aggregation-layers": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.3.1.tgz",
-      "integrity": "sha512-Aikrnrft79kbWjMNENxKF+Gg4JO0y4wkF8fokrr/tXRKaNIy/WV9yPXu3sNKzwZliucV/uJJtAE7DxCtyJl6uw==",
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.3.6.tgz",
+      "integrity": "sha512-shHIzD1fzPXYNqT5MvCW++3LMUA/odF25eWrjwQ6mRwPjwty9jUOEg5UoRYmNUN0fiE00vnc5kzMQVL7T/jDKA==",
       "license": "MIT",
       "dependencies": {
-        "@luma.gl/shadertools": "^9.3.2",
+        "@luma.gl/shadertools": "^9.3.3",
         "@math.gl/core": "^4.1.0",
         "@math.gl/web-mercator": "^4.1.0",
         "d3-hexbin": "^0.2.1"
@@ -34,22 +37,22 @@
       "peerDependencies": {
         "@deck.gl/core": "~9.3.0",
         "@deck.gl/layers": "~9.3.0",
-        "@luma.gl/core": "~9.3.2",
-        "@luma.gl/engine": "~9.3.2"
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
       }
     },
     "node_modules/@deck.gl/core": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.3.1.tgz",
-      "integrity": "sha512-uixmBJhaAAgjzppcJ+0Hh2R1BYvFHvCHFReXN93iQxQoNB3VCC03pGEhZ0hrW7hcVLC8ExCUrg8VRJW60wXzcA==",
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.3.6.tgz",
+      "integrity": "sha512-dCwF+ATE382DdbIqbaoHYCTAW7vutkVlQvWlmMebTDW1j7rPnKrT6ZPa0Y996U/8ZL5NNWc2/wWWY9LYhZVm2Q==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/core": "^4.4.1",
-        "@loaders.gl/images": "^4.4.1",
-        "@luma.gl/core": "^9.3.2",
-        "@luma.gl/engine": "^9.3.2",
-        "@luma.gl/shadertools": "^9.3.2",
-        "@luma.gl/webgl": "^9.3.2",
+        "@loaders.gl/core": "^4.4.3",
+        "@loaders.gl/images": "^4.4.3",
+        "@luma.gl/core": "^9.3.3",
+        "@luma.gl/engine": "^9.3.3",
+        "@luma.gl/shadertools": "^9.3.3",
+        "@luma.gl/webgl": "^9.3.3",
         "@math.gl/core": "^4.1.0",
         "@math.gl/sun": "^4.1.0",
         "@math.gl/types": "^4.1.0",
@@ -80,21 +83,21 @@
       }
     },
     "node_modules/@deck.gl/geo-layers": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.3.1.tgz",
-      "integrity": "sha512-MyQs/mb/+Kp3Y+HARClQxnvCYH0MjkXR+QAyalMdM/bJoVox8sw7k2WkHyzubEH5uKFWX6F509XueC86SrVrZw==",
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.3.6.tgz",
+      "integrity": "sha512-qhRrbVQ05nuxM4H8DnA6kuikTFDZWXVvOMDFBeOHF5k4rsjiyIg5ahIJG0AYuYKMzAeYMNyPDR+diFH1JV0yLg==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/3d-tiles": "^4.4.1",
-        "@loaders.gl/gis": "^4.4.1",
-        "@loaders.gl/loader-utils": "^4.4.1",
-        "@loaders.gl/mvt": "^4.4.1",
-        "@loaders.gl/schema": "^4.4.1",
-        "@loaders.gl/terrain": "^4.4.1",
-        "@loaders.gl/tiles": "^4.4.1",
-        "@loaders.gl/wms": "^4.4.1",
-        "@luma.gl/gltf": "^9.3.2",
-        "@luma.gl/shadertools": "^9.3.2",
+        "@loaders.gl/3d-tiles": "^4.4.3",
+        "@loaders.gl/gis": "^4.4.3",
+        "@loaders.gl/loader-utils": "^4.4.3",
+        "@loaders.gl/mvt": "^4.4.3",
+        "@loaders.gl/schema": "^4.4.3",
+        "@loaders.gl/terrain": "^4.4.3",
+        "@loaders.gl/tiles": "^4.4.3",
+        "@loaders.gl/wms": "^4.4.3",
+        "@luma.gl/gltf": "^9.3.3",
+        "@luma.gl/shadertools": "^9.3.3",
         "@math.gl/core": "^4.1.0",
         "@math.gl/culling": "^4.1.0",
         "@math.gl/web-mercator": "^4.1.0",
@@ -108,70 +111,71 @@
         "@deck.gl/extensions": "~9.3.0",
         "@deck.gl/layers": "~9.3.0",
         "@deck.gl/mesh-layers": "~9.3.0",
-        "@loaders.gl/core": "^4.4.1",
-        "@luma.gl/core": "~9.3.2",
-        "@luma.gl/engine": "~9.3.2"
+        "@loaders.gl/core": "^4.4.3",
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
       }
     },
     "node_modules/@deck.gl/layers": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.3.1.tgz",
-      "integrity": "sha512-gUT/UMrmSCYsJCyv78qjHdeZVnqDexX61WxNP3dUa7ZplXiG3NxZvjhS0PYeBLritOtCJSv3b13vR2ka+j49ZQ==",
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.3.6.tgz",
+      "integrity": "sha512-Ex3Lh4AIQ4zi8iojyWr/kpjwdY9HFKkR0iLeNt0hgz3fOmgL8++5jwUuzt+VOQnjE+x7TsNlM1B1fLciHnH4Xg==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/images": "^4.4.1",
-        "@loaders.gl/schema": "^4.4.1",
-        "@luma.gl/shadertools": "^9.3.2",
+        "@loaders.gl/images": "^4.4.3",
+        "@loaders.gl/schema": "^4.4.3",
+        "@luma.gl/shadertools": "^9.3.3",
         "@mapbox/tiny-sdf": "^2.0.5",
         "@math.gl/core": "^4.1.0",
         "@math.gl/polygon": "^4.1.0",
         "@math.gl/web-mercator": "^4.1.0",
+        "@types/geojson": "^7946.0.16",
         "earcut": "^2.2.4"
       },
       "peerDependencies": {
         "@deck.gl/core": "~9.3.0",
-        "@loaders.gl/core": "^4.4.1",
-        "@luma.gl/core": "~9.3.2",
-        "@luma.gl/engine": "~9.3.2"
+        "@loaders.gl/core": "^4.4.3",
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
       }
     },
     "node_modules/@deck.gl/mapbox": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-9.3.1.tgz",
-      "integrity": "sha512-4SgpWMeZiqiZEiz9yPdr89cVRL8HFcvXLxXUA0ExhMreUdNuK/j2OIQHPhw6vp1xCFbJEEqRelQ0pJYkhGDkYw==",
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-9.3.6.tgz",
+      "integrity": "sha512-EtjN/Dea7Z6w4gb4c5EE2AEUpKAxrwD5wfZQUFu3+In3wXP1cyfbkJwEqwozRHXo06F6sCknXc9zvmgOXyt0uA==",
       "license": "MIT",
       "dependencies": {
         "@math.gl/web-mercator": "^4.1.0"
       },
       "peerDependencies": {
         "@deck.gl/core": "~9.3.0",
-        "@luma.gl/core": "~9.3.2",
+        "@luma.gl/core": "~9.3.3",
         "@math.gl/web-mercator": "^4.1.0"
       }
     },
     "node_modules/@deck.gl/mesh-layers": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.3.1.tgz",
-      "integrity": "sha512-SvLviM1bYcdFZiX2OZ4Hf0zC44brm1gLbP3j92w/Vt+Mp5O0UHGuzKNPA4kdyL1wAuRfKXXfoJZzVg1/YNbT4g==",
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.3.6.tgz",
+      "integrity": "sha512-tKG+gqwSfVQTocH2XlV5o3otUQ/DARJ5vj/JpRv6FTWhUkHo5Acp9BDkvv3Lb5KYx0MkLZyjSKsvai1oAxVAIQ==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/gltf": "^4.4.1",
-        "@loaders.gl/schema": "^4.4.1",
-        "@luma.gl/gltf": "^9.3.2",
-        "@luma.gl/shadertools": "^9.3.2"
+        "@loaders.gl/gltf": "^4.4.3",
+        "@loaders.gl/schema": "^4.4.3",
+        "@luma.gl/gltf": "^9.3.3",
+        "@luma.gl/shadertools": "^9.3.3"
       },
       "peerDependencies": {
         "@deck.gl/core": "~9.3.0",
-        "@luma.gl/core": "~9.3.2",
-        "@luma.gl/engine": "~9.3.2",
-        "@luma.gl/gltf": "~9.3.2",
-        "@luma.gl/shadertools": "~9.3.2"
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3",
+        "@luma.gl/gltf": "~9.3.3",
+        "@luma.gl/shadertools": "~9.3.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
-      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -186,9 +190,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
-      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -203,9 +207,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
-      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -220,9 +224,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
-      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -237,9 +241,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
-      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -254,9 +258,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
-      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -271,9 +275,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -288,9 +292,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
-      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -305,9 +309,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
-      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -322,9 +326,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
-      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -339,9 +343,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
-      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -356,9 +360,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
-      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -373,9 +377,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
-      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -390,9 +394,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
-      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -407,9 +411,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
-      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -424,9 +428,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
-      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -441,9 +445,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
-      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -458,9 +462,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -475,9 +479,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -492,9 +496,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -509,9 +513,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -525,10 +529,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
-      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -543,9 +564,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
-      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -560,9 +581,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
-      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -577,9 +598,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
-      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -594,20 +615,20 @@
       }
     },
     "node_modules/@loaders.gl/3d-tiles": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-4.4.1.tgz",
-      "integrity": "sha512-837MynN5/lqVbuZcqdxFb0CMfT8v0yRlX7TUFKIBdmkS7AeRRrgcrB+XKblrkdZINUcxOs2N/YLVkwC9wLH1Uw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-4.4.3.tgz",
+      "integrity": "sha512-trKDXRYE7xIyH0g2tvDG0SHo/J5sCUhOec70Ne1a5t64/yY+yifQ4B67n4AnSOnZ+l4sxjUypjxhHUqoAeWieQ==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/compression": "4.4.1",
-        "@loaders.gl/crypto": "4.4.1",
-        "@loaders.gl/draco": "4.4.1",
-        "@loaders.gl/gltf": "4.4.1",
-        "@loaders.gl/images": "4.4.1",
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/math": "4.4.1",
-        "@loaders.gl/tiles": "4.4.1",
-        "@loaders.gl/zip": "4.4.1",
+        "@loaders.gl/compression": "4.4.3",
+        "@loaders.gl/crypto": "4.4.3",
+        "@loaders.gl/draco": "4.4.3",
+        "@loaders.gl/gltf": "4.4.3",
+        "@loaders.gl/images": "4.4.3",
+        "@loaders.gl/loader-utils": "4.4.3",
+        "@loaders.gl/math": "4.4.3",
+        "@loaders.gl/tiles": "4.4.3",
+        "@loaders.gl/zip": "4.4.3",
         "@math.gl/core": "^4.1.0",
         "@math.gl/culling": "^4.1.0",
         "@math.gl/geospatial": "^4.1.0",
@@ -625,13 +646,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@loaders.gl/compression": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/compression/-/compression-4.4.1.tgz",
-      "integrity": "sha512-MKtGbqHBH7xRVFKyB3E9xRqRMwNW8H72OKpUBDdFwP+hQ0mjHZuud0GeYm5pP50+7o3J2PrES06kHTwT4fg7oQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/compression/-/compression-4.4.3.tgz",
+      "integrity": "sha512-v3feEE48FblxBPaILwejV48plcLmjvOh2yBQrgvKvLCaQdQ9bVz7PzhrUdLW0VDVlGnoR1NUJtI833627U8Heg==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/worker-utils": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.3",
+        "@loaders.gl/worker-utils": "4.4.3",
         "@types/pako": "^1.0.1",
         "fflate": "0.7.4",
         "pako": "1.0.11",
@@ -648,26 +669,26 @@
       }
     },
     "node_modules/@loaders.gl/core": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-4.4.1.tgz",
-      "integrity": "sha512-/s4IuvCCQUepvhjLnmePwQppGko2d1pxRS+sp7lyExU0uiqo5dVsAKaCZ2VnddBkFWgDVb/wvcZUBmv/dWcj0Q==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-4.4.3.tgz",
+      "integrity": "sha512-D6kXFdpUtYwoqS5OQLLaLELkHlS3qIdcSgzVvsh/MinRteeVIITJojqEc/lmDx1zVR3j6WND7yPGF4i4aOwiOg==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/schema": "4.4.1",
-        "@loaders.gl/schema-utils": "4.4.1",
-        "@loaders.gl/worker-utils": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.3",
+        "@loaders.gl/schema": "4.4.3",
+        "@loaders.gl/schema-utils": "4.4.3",
+        "@loaders.gl/worker-utils": "4.4.3",
         "@probe.gl/log": "^4.1.1"
       }
     },
     "node_modules/@loaders.gl/crypto": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/crypto/-/crypto-4.4.1.tgz",
-      "integrity": "sha512-ORhS9GSYr9uVTU4I2Taa46XBgPPG+nKErKcyDGIXov3gs0EtgMqs8nU4epuLbsJN3+du6FkQaILyGSZlTxbA7Q==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/crypto/-/crypto-4.4.3.tgz",
+      "integrity": "sha512-zratEvtj/Mdbu0NwwwzdbP1oyY4FNxLcOY2JRcYqe3wzw+0kyeK7THdaVPcduZAnQ06HtpwHls61ONZunjMtXA==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/worker-utils": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.3",
+        "@loaders.gl/worker-utils": "4.4.3",
         "@types/crypto-js": "^4.0.2"
       },
       "peerDependencies": {
@@ -675,15 +696,15 @@
       }
     },
     "node_modules/@loaders.gl/draco": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-4.4.1.tgz",
-      "integrity": "sha512-EcapVlkP8Pz53VKg9pYRQUzqm9jH+A+7vGE1kV8nkv63lN8/qtFzBSWMiC6IX1CwxjKJDEINU9Sh8YB1AfMwbQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-4.4.3.tgz",
+      "integrity": "sha512-YNI1MUDDIbrJBamgU1emLBC2kQUbESNIOZv9bcS8xwxr9SNMfnAMZWgdUJkYcC5xzV2q6ty2I/b2eGhXQkd9EQ==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/schema": "4.4.1",
-        "@loaders.gl/schema-utils": "4.4.1",
-        "@loaders.gl/worker-utils": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.3",
+        "@loaders.gl/schema": "4.4.3",
+        "@loaders.gl/schema-utils": "4.4.3",
+        "@loaders.gl/worker-utils": "4.4.3",
         "draco3d": "1.5.7"
       },
       "peerDependencies": {
@@ -691,9 +712,9 @@
       }
     },
     "node_modules/@loaders.gl/geoarrow": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/geoarrow/-/geoarrow-4.4.1.tgz",
-      "integrity": "sha512-d9+AxsNpdJzilgHTFnyycoIocp4b+iEX3bbCCAEdUm/7eZbOdM7sFcgLLiGVTehtGnOUOICskjrzT27gqmzDqg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/geoarrow/-/geoarrow-4.4.3.tgz",
+      "integrity": "sha512-P0TSbtsw1UI1rZnp1tGHuqPVHcH7Yc14q9jZLIcrjhQOzol55YDI0/hYSXpA73794nR6o8ALxNwiy7/4HlBlcA==",
       "license": "MIT",
       "dependencies": {
         "@math.gl/polygon": "^4.1.0",
@@ -704,15 +725,15 @@
       }
     },
     "node_modules/@loaders.gl/gis": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-4.4.1.tgz",
-      "integrity": "sha512-M9Z9jXwye4SjlD1hAFJwE3+eZiN1lprwlSkWIo7R642kN5r3R60M9fqBD1mvCTBj96FPmbsyOm1eYKS0XCpKxQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-4.4.3.tgz",
+      "integrity": "sha512-2dhhzfCT1cXQQLZ1lMtb2Y+pX414qaeLL8Wpx7FJu/ar1HJfKL6Fb3juTR+2WzMybkAOX5zLxYh6+y7LqiPjgA==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/geoarrow": "4.4.1",
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/schema": "4.4.1",
-        "@loaders.gl/schema-utils": "4.4.1",
+        "@loaders.gl/geoarrow": "4.4.3",
+        "@loaders.gl/loader-utils": "4.4.3",
+        "@loaders.gl/schema": "4.4.3",
+        "@loaders.gl/schema-utils": "4.4.3",
         "@mapbox/vector-tile": "^1.3.1",
         "@math.gl/polygon": "^4.1.0",
         "pbf": "^3.2.1"
@@ -722,16 +743,16 @@
       }
     },
     "node_modules/@loaders.gl/gltf": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-4.4.1.tgz",
-      "integrity": "sha512-9ESHEm3YoMgsQh8QS1N99uwA+cij6p6xhCmZnHX4rQnqHm0jvE5RAHlGV1D/Xjvr4PR8IiXaBn/QDl/qdGIxkw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-4.4.3.tgz",
+      "integrity": "sha512-OYE/0nGLYm3weiCb78+ROwdNVyuLS8IZwN8NvGqctqt0HS4ZD40biu7b9L8xkFbVTZQkQZXDpyZ61n5PSQeU1A==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/draco": "4.4.1",
-        "@loaders.gl/images": "4.4.1",
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/schema": "4.4.1",
-        "@loaders.gl/textures": "4.4.1",
+        "@loaders.gl/draco": "4.4.3",
+        "@loaders.gl/images": "4.4.3",
+        "@loaders.gl/loader-utils": "4.4.3",
+        "@loaders.gl/schema": "4.4.3",
+        "@loaders.gl/textures": "4.4.3",
         "@math.gl/core": "^4.1.0"
       },
       "peerDependencies": {
@@ -739,33 +760,33 @@
       }
     },
     "node_modules/@loaders.gl/images": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-4.4.1.tgz",
-      "integrity": "sha512-v9A4BliEKGxhLuEbh0Ke8ElUlp04KxpKIknUtXXWoEaszAMTSrHI3YhaL/JdRlHraC1VUF/sjzbSBFkKh7nxJg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-4.4.3.tgz",
+      "integrity": "sha512-a4C6x+4GZUchf+IwpdBOvyGeLGSbGOVob+WSWfGUezEQ4gqu1zS1pn3lCX3ZTL5P+Ch3v6KKwPGdO5YdTd52Ew==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.4.1"
+        "@loaders.gl/loader-utils": "4.4.3"
       },
       "peerDependencies": {
         "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/loader-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.1.tgz",
-      "integrity": "sha512-waosL7VtVRfXsNOXtAM3rOjZyNQD0lQBlhuB5/oY+E+lNzYNFlzgiGXiDOwBpcs7dK7kW2Vv8+KcxyIGIyXOtg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.3.tgz",
+      "integrity": "sha512-5yt1OqZPYR3d+xFAqtzSKO24Hd7019KqN+iOWp7XBKPQBS+sAEhAnmSTnO1axo45IEi14J3FhMDk+ndqBoSKEQ==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/schema": "4.4.1",
-        "@loaders.gl/worker-utils": "4.4.1",
+        "@loaders.gl/schema": "4.4.3",
+        "@loaders.gl/worker-utils": "4.4.3",
         "@probe.gl/log": "^4.1.1",
         "@probe.gl/stats": "^4.1.1"
       }
     },
     "node_modules/@loaders.gl/math": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-4.4.1.tgz",
-      "integrity": "sha512-xenAPOAUd7HDlus5V/g4LKVh1l7FpyVRSYXa+g7tBj91xzhRYgLEXSxdrGfRNAFMDOSGC1ITwCGQwlwSX4Mpxw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-4.4.3.tgz",
+      "integrity": "sha512-EdEsZGqo1AX3sqgXt8bSBmdo+8ncURXjWucyQ8eeIJ2h0VIqM3bLkOGKk/D1ngeqK4hJXcjiturYHBW1B286lw==",
       "license": "MIT",
       "dependencies": {
         "@math.gl/core": "^4.1.0"
@@ -775,15 +796,15 @@
       }
     },
     "node_modules/@loaders.gl/mvt": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-4.4.1.tgz",
-      "integrity": "sha512-ou1Oyec7hcpCQ2onF1FefNXVv1MwPjwUkII6IFrrRZ/f0/ei0b8yc5IVwO4gkhta/Ve/Y+mFcs/GaeQZMOEBOg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-4.4.3.tgz",
+      "integrity": "sha512-s2R8GRlaWDfZ7oKDFiY0c5EJ8elkf2VbPvdC0eoh69DN71y+AKngDSB+7h4veH/oueLEjmV7tNlF0+Snv58CPw==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/gis": "4.4.1",
-        "@loaders.gl/images": "4.4.1",
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/gis": "4.4.3",
+        "@loaders.gl/images": "4.4.3",
+        "@loaders.gl/loader-utils": "4.4.3",
+        "@loaders.gl/schema": "4.4.3",
         "@math.gl/polygon": "^4.1.0",
         "@probe.gl/stats": "^4.1.1",
         "pbf": "^3.2.1"
@@ -793,9 +814,9 @@
       }
     },
     "node_modules/@loaders.gl/schema": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.1.tgz",
-      "integrity": "sha512-s7NjEnyK6jZvJJSWj/mHq+S9mHRHVzIYtFP+C7sMf1gVCQbdkt6OSAMUWRzwPr9+whQNVWjZ9pbLsI/IPW3zvw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.3.tgz",
+      "integrity": "sha512-tDb/rOn44nHWvMFSOaAk1/pQcQcusxirGCM1O5BMJR0PQ71UrCHey56rsbcf7/wGhvyRwPtX+oiMzlJ9TmN8vQ==",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.7",
@@ -803,12 +824,12 @@
       }
     },
     "node_modules/@loaders.gl/schema-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema-utils/-/schema-utils-4.4.1.tgz",
-      "integrity": "sha512-4upip2O6MFaWzk68/lnna7P2uRj9NQ8MIk/ff3CLbciP5/9lKl1qyuzObz5JrJRYzfGB6I81vpOn6FSVQ6m6KQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema-utils/-/schema-utils-4.4.3.tgz",
+      "integrity": "sha512-TggzQWkzf9pIYbj8I9RlTk33kwXslvDkY1nnw/OL/hika6qTls1G127qK5m9skiAjElk5ZkvQLQcwhOboZXZeA==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/schema": "4.4.3",
         "@types/geojson": "^7946.0.7",
         "apache-arrow": ">= 17.0.0"
       },
@@ -817,14 +838,14 @@
       }
     },
     "node_modules/@loaders.gl/terrain": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-4.4.1.tgz",
-      "integrity": "sha512-cBLT+G0HefySTppxqqkMKcN5kfOfIRRx0WDPHa0VHFJw9rbnxoEDhrXvfsXfOATNFFNtcpgQUDqDqhEBp0XvZw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-4.4.3.tgz",
+      "integrity": "sha512-wu7O3FVXE6D1kSm5inRu8M8V1Vv5AYlnlNB0EJIOSSXBLhfNbPL5oHjlD2wIlag0gSxOVlhWjCUcWS3/Nb0P8Q==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/images": "4.4.1",
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/images": "4.4.3",
+        "@loaders.gl/loader-utils": "4.4.3",
+        "@loaders.gl/schema": "4.4.3",
         "@mapbox/martini": "^0.2.0"
       },
       "peerDependencies": {
@@ -832,15 +853,15 @@
       }
     },
     "node_modules/@loaders.gl/textures": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-4.4.1.tgz",
-      "integrity": "sha512-r1//6sO29GOHso+IvXQ3GrvXZ4cl03VWc34XcnXPn3sAV7O96uRGd5xkyx60lMYAl7Jv7qK/smT3z4Mdxdd4aA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-4.4.3.tgz",
+      "integrity": "sha512-QNC+anwJJcHsLsaAzXozJ+IUNxBnqWsZLUMkUZIorVey+XQcp2hcYng5iOmUQnCZdIR9gYe53VJa0j1C0JXRSg==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/images": "4.4.1",
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/schema": "4.4.1",
-        "@loaders.gl/worker-utils": "4.4.1",
+        "@loaders.gl/images": "4.4.3",
+        "@loaders.gl/loader-utils": "4.4.3",
+        "@loaders.gl/schema": "4.4.3",
+        "@loaders.gl/worker-utils": "4.4.3",
         "@math.gl/types": "^4.1.0",
         "ktx-parse": "^0.7.0",
         "texture-compressor": "^1.0.2"
@@ -850,13 +871,13 @@
       }
     },
     "node_modules/@loaders.gl/tiles": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-4.4.1.tgz",
-      "integrity": "sha512-EbF81/c1oXJocVAKR0rx+vWSOnmBBWWhM7pZpYk6oNUQAJfA99APhiRNstAJiJomAgqAxr7vfnhXHjPZg6osZw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-4.4.3.tgz",
+      "integrity": "sha512-8ZkPMe+daMV5mHKTEU591mJSp6pswdWliI+PcNhSOkpeuvyjecaYKSzuzMFMmaywfgOLpYl+lpfzKUEmCcE5vQ==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/math": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.3",
+        "@loaders.gl/math": "4.4.3",
         "@math.gl/core": "^4.1.0",
         "@math.gl/culling": "^4.1.0",
         "@math.gl/geospatial": "^4.1.0",
@@ -868,15 +889,15 @@
       }
     },
     "node_modules/@loaders.gl/wms": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/wms/-/wms-4.4.1.tgz",
-      "integrity": "sha512-sIaqyHXPuLQnkN2eebvczZYVvapkjA8EZaI8feaPxj4jZk/Hk5EuZzIbxJ4eftLotZwDHd3XzEVIs6YlFOSJ+Q==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/wms/-/wms-4.4.3.tgz",
+      "integrity": "sha512-fKYCdIp6xQcucbm42bztprlfMJ5SZKx5f2ZwWLcj+kwv53U7hjcbIl04uMAk/i/7Xw/I4QEyA/XnPnxquuIFHQ==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/images": "4.4.1",
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/schema": "4.4.1",
-        "@loaders.gl/xml": "4.4.1",
+        "@loaders.gl/images": "4.4.3",
+        "@loaders.gl/loader-utils": "4.4.3",
+        "@loaders.gl/schema": "4.4.3",
+        "@loaders.gl/xml": "4.4.3",
         "@turf/rewind": "^5.1.5",
         "deep-strict-equal": "^0.2.0"
       },
@@ -885,22 +906,22 @@
       }
     },
     "node_modules/@loaders.gl/worker-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.1.tgz",
-      "integrity": "sha512-ovMyIyj9dlChuHuD64Bel7Mir2UYlmLqlZ9MMzVxzTTLvaudJoNAXi6Disp0ooxwF62ZqjNXXutaSbS6UDeuIg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.3.tgz",
+      "integrity": "sha512-RZt/NwFXm6Kx3Fn/rqiW3Alse9Z0XtBktH/EFAp8W6LvsKuxpRMjULqGfybTu2waRXRYUNYZ6zGs9aOWbtDRLw==",
       "license": "MIT",
       "peerDependencies": {
         "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/xml": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/xml/-/xml-4.4.1.tgz",
-      "integrity": "sha512-+8Dtxp0BZZj1CVUkiIlKGDLmhwsPILK9yJvc1P7tuJO9KsaQ5cywJk/b8A7lmqb2SfPkEg0xlQOK2FWIo1ATMA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/xml/-/xml-4.4.3.tgz",
+      "integrity": "sha512-/CtpIWaPKBs/AaX7MqUGSSE1OAhq78nDrJ5xPExYdIQAw5gl5OSmLZobUSSxV5FGaqkJRVbtC/sj5sUpci7doA==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.3",
+        "@loaders.gl/schema": "4.4.3",
         "fast-xml-parser": "^5.3.6"
       },
       "peerDependencies": {
@@ -908,14 +929,14 @@
       }
     },
     "node_modules/@loaders.gl/zip": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/zip/-/zip-4.4.1.tgz",
-      "integrity": "sha512-fV7oqREEzzqYl2/b4tiM+J4qeSq6pB4gw1hHngpCtVyjVwWVtsNH2r1ly9kkv4XssIdXJxPcrX/GR0mDIwmp6w==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/zip/-/zip-4.4.3.tgz",
+      "integrity": "sha512-HH/JLulJJVyqmbQYp4e/9MPjaTnUFnWfhgza8sMGIBYZ/YuZXOc6Ad2vvmyFQHvNbVr+NLrRZODASEjNZQ5rfQ==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/compression": "4.4.1",
-        "@loaders.gl/crypto": "4.4.1",
-        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/compression": "4.4.3",
+        "@loaders.gl/crypto": "4.4.3",
+        "@loaders.gl/loader-utils": "4.4.3",
         "jszip": "^3.1.5",
         "md5": "^2.3.0"
       },
@@ -1199,9 +1220,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
       "funding": [
         {
           "type": "github",
@@ -1331,13 +1352,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/offscreencanvas": {
@@ -1384,6 +1405,18 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/apache-arrow": {
       "version": "21.1.0",
@@ -1633,9 +1666,9 @@
       "license": "ISC"
     },
     "node_modules/esbuild": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
-      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1646,37 +1679,38 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.24.2",
-        "@esbuild/android-arm": "0.24.2",
-        "@esbuild/android-arm64": "0.24.2",
-        "@esbuild/android-x64": "0.24.2",
-        "@esbuild/darwin-arm64": "0.24.2",
-        "@esbuild/darwin-x64": "0.24.2",
-        "@esbuild/freebsd-arm64": "0.24.2",
-        "@esbuild/freebsd-x64": "0.24.2",
-        "@esbuild/linux-arm": "0.24.2",
-        "@esbuild/linux-arm64": "0.24.2",
-        "@esbuild/linux-ia32": "0.24.2",
-        "@esbuild/linux-loong64": "0.24.2",
-        "@esbuild/linux-mips64el": "0.24.2",
-        "@esbuild/linux-ppc64": "0.24.2",
-        "@esbuild/linux-riscv64": "0.24.2",
-        "@esbuild/linux-s390x": "0.24.2",
-        "@esbuild/linux-x64": "0.24.2",
-        "@esbuild/netbsd-arm64": "0.24.2",
-        "@esbuild/netbsd-x64": "0.24.2",
-        "@esbuild/openbsd-arm64": "0.24.2",
-        "@esbuild/openbsd-x64": "0.24.2",
-        "@esbuild/sunos-x64": "0.24.2",
-        "@esbuild/win32-arm64": "0.24.2",
-        "@esbuild/win32-ia32": "0.24.2",
-        "@esbuild/win32-x64": "0.24.2"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.1.tgz",
+      "integrity": "sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==",
       "funding": [
         {
           "type": "github",
@@ -1685,13 +1719,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
-      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+      "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
       "funding": [
         {
           "type": "github",
@@ -1700,10 +1735,12 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "@nodable/entities": "^2.2.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^1.0.1",
         "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -1818,6 +1855,18 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.2.tgz",
       "integrity": "sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg==",
+      "license": "MIT"
+    },
+    "node_modules/is-unsafe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/isarray": {
@@ -2003,9 +2052,9 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
       "funding": [
         {
           "type": "github",
@@ -2118,16 +2167,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
     },
     "node_modules/supercluster": {
       "version": "8.0.1",
@@ -2198,9 +2250,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT",
       "optional": true
     },
@@ -2217,6 +2269,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.17"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/zstd-codec": {

--- a/js/package.json
+++ b/js/package.json
@@ -11,15 +11,15 @@
     "watch": "node esbuild.config.mjs --watch"
   },
   "dependencies": {
-    "@deck.gl/core": "^9.3.1",
-    "@deck.gl/layers": "^9.3.1",
-    "@deck.gl/aggregation-layers": "^9.3.1",
-    "@deck.gl/geo-layers": "^9.3.1",
-    "@deck.gl/mesh-layers": "^9.3.1",
-    "@deck.gl/mapbox": "^9.3.1",
-    "maplibre-gl": "^5.24.0"
+    "@deck.gl/core": "~9.3.6",
+    "@deck.gl/layers": "~9.3.6",
+    "@deck.gl/aggregation-layers": "~9.3.6",
+    "@deck.gl/geo-layers": "~9.3.6",
+    "@deck.gl/mesh-layers": "~9.3.6",
+    "@deck.gl/mapbox": "~9.3.6",
+    "maplibre-gl": "~5.24.0"
   },
   "devDependencies": {
-    "esbuild": "^0.24.0"
+    "esbuild": "^0.28.1"
   }
 }


### PR DESCRIPTION
Closes #14, closes #15.

**Chain position: 3/20 — stacked on #39 (feat/python-deps).**

## What

- All six `@deck.gl/*` packages **tilde-pinned at `~9.3.6`** (registry-verified latest; no deck.gl 9.4 or 10 exists). Gains over the old `^9.3.1`/lock-9.3.0: the 9.3.4 **ColumnLayer closed-shapes-with-binary-data fix** (deck.gl#10094), the 9.3.4 event-recognizer fix (deck.gl#10323), and 9.3.2/9.3.6 type corrections.
- `maplibre-gl` tilde-pinned at `~5.24.0` — already the latest stable. The v6 prerelease removes `map.transform` (which `@deck.gl/mapbox` reads); upgrade is blocked on deck.gl support and tracked in #17.
- `esbuild` → `^0.28.1`: security fixes (dev-server origin check GHSA-67mh-4wv8-2f99 in 0.25.0, path-traversal fix in 0.28.1) plus minifier correctness. No `build()` API changes affect our config. Note caret never crosses 0.x minors, so future esbuild bumps stay manual.
- Tilde pins make patch drift deliberate — same reproducibility posture as deckgl_dash.

## Verification

- `npm install` resolves deck.gl 9.3.6 / maplibre 5.24.0 / esbuild 0.28.1; 0 vulnerabilities
- Bundle rebuilds cleanly under esbuild 0.28.1 at the same 2.5 MB size
- Python suite (233) and `check_versions.py` still green (lockfile version field stays 0.6.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MB6bkjREt8tm7UkFjrogki
