### PR TITLE
Split index.js into testable modules; add vitest suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
         run: npm ci
         working-directory: js
 
+      - name: JS unit tests
+        run: npm test
+        working-directory: js
+
       - name: Build JS bundle
         run: npm run build
         working-directory: js

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -17,7 +17,8 @@
         "maplibre-gl": "~5.24.0"
       },
       "devDependencies": {
-        "esbuild": "^0.28.1"
+        "esbuild": "^0.28.1",
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": ">=20.9"
@@ -170,6 +171,40 @@
         "@luma.gl/engine": "~9.3.3",
         "@luma.gl/gltf": "~9.3.3",
         "@luma.gl/shadertools": "~9.3.3"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -613,6 +648,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@loaders.gl/3d-tiles": {
       "version": "4.4.3",
@@ -1219,6 +1261,25 @@
         "@math.gl/core": "4.1.0"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
@@ -1230,6 +1291,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
     },
     "node_modules/@probe.gl/env": {
       "version": "4.1.1",
@@ -1250,6 +1321,295 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.1.1.tgz",
       "integrity": "sha512-4VpAyMHOqydSvPlEyHwXaE+AkIdR03nX+Qhlxsk2D/IW4OVmDZgIsvJB1cDzyEEtcfKcnaEbfXeiPgejBceT6g==",
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -1317,6 +1677,17 @@
         "@turf/meta": "^5.1.5"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/brotli": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/brotli/-/brotli-1.3.5.tgz",
@@ -1325,6 +1696,17 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/command-line-args": {
@@ -1343,6 +1725,20 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
       "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/geojson": {
@@ -1380,6 +1776,119 @@
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/a5-js": {
@@ -1471,6 +1980,16 @@
         "node": ">=12.17"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1509,6 +2028,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1607,6 +2136,13 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/core-assert": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
@@ -1653,6 +2189,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/draco3d": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
@@ -1664,6 +2210,13 @@
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
       "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -1707,6 +2260,26 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-xml-builder": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.1.tgz",
@@ -1746,6 +2319,24 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fflate": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
@@ -1774,6 +2365,21 @@
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
       "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/gl-matrix": {
       "version": "3.4.4",
@@ -1922,6 +2528,279 @@
         "immediate": "~3.0.5"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -1943,6 +2822,16 @@
       "integrity": "sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/maplibre-gl": {
       "version": "5.24.0",
@@ -2045,6 +2934,39 @@
       "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -2066,6 +2988,13 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pbf": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
@@ -2077,6 +3006,55 @@
       },
       "bin": {
         "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/potpack": {
@@ -2127,6 +3105,40 @@
         "protocol-buffers-schema": "^3.3.1"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
     "node_modules/rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
@@ -2145,17 +3157,48 @@
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/snappyjs": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/snappyjs/-/snappyjs-0.6.1.tgz",
       "integrity": "sha512-YIK6I2lsH072UE0aOFxxY1dPDCS43I5ktqHpeAsuLNYWkE5pGxRGWfDM4/vSUfNzXjC1Ivzt3qx31PCLmc9yqg==",
       "license": "MIT"
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -2228,11 +3271,55 @@
         "texture-compressor": "bin/texture-compressor.js"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/tinyqueue": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
       "license": "ISC"
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -2261,6 +3348,191 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/wordwrapjs": {
       "version": "5.1.1",

--- a/js/package.json
+++ b/js/package.json
@@ -8,18 +8,21 @@
   },
   "scripts": {
     "build": "node esbuild.config.mjs",
-    "watch": "node esbuild.config.mjs --watch"
+    "watch": "node esbuild.config.mjs --watch",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
-    "@deck.gl/core": "~9.3.6",
-    "@deck.gl/layers": "~9.3.6",
     "@deck.gl/aggregation-layers": "~9.3.6",
+    "@deck.gl/core": "~9.3.6",
     "@deck.gl/geo-layers": "~9.3.6",
-    "@deck.gl/mesh-layers": "~9.3.6",
+    "@deck.gl/layers": "~9.3.6",
     "@deck.gl/mapbox": "~9.3.6",
+    "@deck.gl/mesh-layers": "~9.3.6",
     "maplibre-gl": "~5.24.0"
   },
   "devDependencies": {
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "vitest": "^4.1.10"
   }
 }

--- a/js/src/__tests__/accessor-resolver.test.js
+++ b/js/src/__tests__/accessor-resolver.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { resolveAccessors } from "../accessor-resolver.js";
+
+const data = [
+  { lon: 1, lat: 2, size: 10, name: "a" },
+  { lon: 3, lat: 4, size: 20, name: "b" },
+];
+
+describe("resolveAccessors", () => {
+  it("converts a column-name string into a row accessor", () => {
+    const props = { getRadius: "size", data };
+    resolveAccessors(props, data);
+    expect(typeof props.getRadius).toBe("function");
+    expect(props.getRadius(data[1])).toBe(20);
+  });
+
+  it("leaves non-column strings as constants (e.g. TextLayer anchors)", () => {
+    const props = { getTextAnchor: "middle", data };
+    resolveAccessors(props, data);
+    expect(props.getTextAnchor).toBe("middle");
+  });
+
+  it("converts a column-name list into a vector accessor", () => {
+    const props = { getPosition: ["lon", "lat"], data };
+    resolveAccessors(props, data);
+    expect(props.getPosition(data[0])).toEqual([1, 2]);
+  });
+
+  it("passes small numeric arrays through as RGBA constants", () => {
+    const props = { getFillColor: [255, 0, 0, 255], data };
+    resolveAccessors(props, data);
+    expect(props.getFillColor).toEqual([255, 0, 0, 255]);
+  });
+
+  it("converts a per-row array matching data length into an indexed accessor", () => {
+    const perRow = [
+      [255, 0, 0, 255],
+      [0, 255, 0, 255],
+    ];
+    const props = { getFillColor: perRow, data };
+    resolveAccessors(props, data);
+    expect(typeof props.getFillColor).toBe("function");
+    expect(props.getFillColor(null, { index: 1 })).toEqual([0, 255, 0, 255]);
+  });
+
+  it("only touches get* accessor props", () => {
+    const props = { radiusScale: 5, stroked: true, data };
+    resolveAccessors(props, data);
+    expect(props.radiusScale).toBe(5);
+    expect(props.stroked).toBe(true);
+  });
+
+  it("leaves existing functions alone", () => {
+    const fn = (d) => d.size * 2;
+    const props = { getRadius: fn, data };
+    resolveAccessors(props, data);
+    expect(props.getRadius).toBe(fn);
+  });
+});

--- a/js/src/__tests__/binary-buffer.test.js
+++ b/js/src/__tests__/binary-buffer.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { normalizeBinaryBuffer } from "../binary-buffer.js";
+
+describe("normalizeBinaryBuffer", () => {
+  it("returns null for empty input", () => {
+    expect(normalizeBinaryBuffer(null)).toBeNull();
+    expect(normalizeBinaryBuffer(undefined)).toBeNull();
+    expect(normalizeBinaryBuffer("")).toBeNull();
+  });
+
+  it("copies a DataView slice with a non-zero byteOffset into a standalone buffer", () => {
+    // Backing buffer: [0,1,2,3,4,5,6,7]; DataView covers [2..5]
+    const backing = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]).buffer;
+    const view = new DataView(backing, 2, 4);
+    const out = normalizeBinaryBuffer(view);
+    expect(out).toBeInstanceOf(ArrayBuffer);
+    expect(out).not.toBe(backing);
+    expect(out.byteLength).toBe(4);
+    expect(Array.from(new Uint8Array(out))).toEqual([2, 3, 4, 5]);
+  });
+
+  it("passes a bare ArrayBuffer through unchanged", () => {
+    const buf = new Uint8Array([9, 8, 7]).buffer;
+    expect(normalizeBinaryBuffer(buf)).toBe(buf);
+  });
+
+  it("copies a typed-array view (offset subarray) into a standalone buffer", () => {
+    const backing = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);
+    const sub = backing.subarray(3, 6); // bytes [3,4,5]
+    const out = normalizeBinaryBuffer(sub);
+    expect(out).toBeInstanceOf(ArrayBuffer);
+    expect(Array.from(new Uint8Array(out))).toEqual([3, 4, 5]);
+  });
+
+  it("returns null for objects with no usable buffer", () => {
+    expect(normalizeBinaryBuffer({ buffer: "nope" })).toBeNull();
+  });
+});

--- a/js/src/__tests__/binary-data.test.js
+++ b/js/src/__tests__/binary-data.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { applyBinaryData } from "../binary-data.js";
+
+/**
+ * Build a packed buffer the way Python's pack_binary does: startIndices
+ * first (4-byte aligned), then each attribute aligned to its dtype.
+ */
+function packFixture() {
+  // Layer "pts": 2 points, positions float32 x2, colors uint8 x4
+  const positions = new Float32Array([10.5, 20.5, -30.25, 40.75]); // 16 bytes @ 0
+  const colors = new Uint8Array([255, 0, 0, 255, 0, 255, 0, 128]); // 8 bytes @ 16
+  const buffer = new ArrayBuffer(24);
+  new Uint8Array(buffer).set(new Uint8Array(positions.buffer), 0);
+  new Uint8Array(buffer).set(colors, 16);
+
+  const metadata = {
+    layers: [
+      {
+        id: "pts",
+        length: 2,
+        attributes: {
+          getPosition: { offset: 0, byteLength: 16, dtype: "float32", size: 2 },
+          getFillColor: { offset: 16, byteLength: 8, dtype: "uint8", size: 4 },
+        },
+        tooltips: ["first", "second"],
+      },
+    ],
+  };
+  return { buffer, metadata };
+}
+
+describe("applyBinaryData", () => {
+  it("reconstructs typed arrays with correct offsets, values, and sizes", () => {
+    const { buffer, metadata } = packFixture();
+    const specs = [{ id: "pts", type: "ScatterplotLayer" }];
+    applyBinaryData(specs, buffer, metadata);
+
+    const spec = specs[0];
+    expect(spec._binary).toBe(true);
+    expect(spec.data.length).toBe(2);
+    expect(spec.data.attributes.getPosition.size).toBe(2);
+    expect(Array.from(spec.data.attributes.getPosition.value)).toEqual([10.5, 20.5, -30.25, 40.75]);
+    expect(spec.data.attributes.getFillColor.size).toBe(4);
+    expect(Array.from(spec.data.attributes.getFillColor.value)).toEqual([255, 0, 0, 255, 0, 255, 0, 128]);
+    expect(spec._tooltips).toEqual(["first", "second"]);
+  });
+
+  it("builds startIndices for variable-length layers", () => {
+    // startIndices uint32 [0, 3] @ 0 (8 bytes), path coords float32 @ 8
+    const si = new Uint32Array([0, 3]);
+    const coords = new Float32Array([0, 0, 1, 1, 2, 2, 5, 5, 6, 6]); // 40 bytes
+    const buffer = new ArrayBuffer(48);
+    new Uint8Array(buffer).set(new Uint8Array(si.buffer), 0);
+    new Uint8Array(buffer).set(new Uint8Array(coords.buffer), 8);
+
+    const metadata = {
+      layers: [
+        {
+          id: "paths",
+          length: 2,
+          startIndices: { offset: 0, byteLength: 8, dtype: "uint32" },
+          attributes: {
+            getPath: { offset: 8, byteLength: 40, dtype: "float32", size: 2 },
+          },
+        },
+      ],
+    };
+    const specs = [{ id: "paths", type: "PathLayer" }];
+    applyBinaryData(specs, buffer, metadata);
+
+    expect(Array.from(specs[0].data.startIndices)).toEqual([0, 3]);
+    expect(specs[0].data.attributes.getPath.value.length).toBe(10);
+  });
+
+  it("leaves specs without matching metadata untouched", () => {
+    const { buffer, metadata } = packFixture();
+    const specs = [{ id: "other", type: "ScatterplotLayer", data: [{ a: 1 }] }];
+    applyBinaryData(specs, buffer, metadata);
+    expect(specs[0]._binary).toBeUndefined();
+    expect(specs[0].data).toEqual([{ a: 1 }]);
+  });
+
+  it("is a no-op for empty buffers or missing metadata", () => {
+    const specs = [{ id: "pts" }];
+    applyBinaryData(specs, new ArrayBuffer(0), { layers: [{ id: "pts", attributes: {} }] });
+    applyBinaryData(specs, null, { layers: [] });
+    applyBinaryData(specs, new ArrayBuffer(8), null);
+    expect(specs[0].data).toBeUndefined();
+  });
+});

--- a/js/src/__tests__/zoom-visibility.test.js
+++ b/js/src/__tests__/zoom-visibility.test.js
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { applyZoomVisibility, isInZoomRange, zoomVisibilityKey } from "../zoom-visibility.js";
+
+describe("isInZoomRange", () => {
+  it("is unbounded when neither bound is set", () => {
+    expect(isInZoomRange({}, 0)).toBe(true);
+    expect(isInZoomRange({}, 22)).toBe(true);
+  });
+
+  it("applies inclusive min and max bounds", () => {
+    const spec = { minZoom: 5, maxZoom: 10 };
+    expect(isInZoomRange(spec, 4.99)).toBe(false);
+    expect(isInZoomRange(spec, 5)).toBe(true);
+    expect(isInZoomRange(spec, 10)).toBe(true);
+    expect(isInZoomRange(spec, 10.01)).toBe(false);
+  });
+
+  it("supports one-sided bounds", () => {
+    expect(isInZoomRange({ minZoom: 8 }, 7)).toBe(false);
+    expect(isInZoomRange({ minZoom: 8 }, 9)).toBe(true);
+    expect(isInZoomRange({ maxZoom: 8 }, 7)).toBe(true);
+    expect(isInZoomRange({ maxZoom: 8 }, 9)).toBe(false);
+  });
+});
+
+describe("applyZoomVisibility", () => {
+  it("leaves ungated specs untouched", () => {
+    const specs = [{ id: "a", visible: true }];
+    applyZoomVisibility(specs, 3);
+    expect(specs[0].visible).toBe(true);
+    expect(specs[0]._userVisible).toBeUndefined();
+  });
+
+  it("gates visibility by zoom range", () => {
+    const specs = [{ id: "a", visible: true, minZoom: 5 }];
+    applyZoomVisibility(specs, 3);
+    expect(specs[0].visible).toBe(false);
+    applyZoomVisibility(specs, 6);
+    expect(specs[0].visible).toBe(true);
+  });
+
+  it("is idempotent: repeated calls never lose the user-supplied visible", () => {
+    const specs = [{ id: "a", visible: false, minZoom: 5 }];
+    applyZoomVisibility(specs, 6);
+    expect(specs[0].visible).toBe(false); // user said hidden — stays hidden in range
+    applyZoomVisibility(specs, 3);
+    applyZoomVisibility(specs, 6);
+    expect(specs[0].visible).toBe(false);
+    expect(specs[0]._userVisible).toBe(false);
+  });
+
+  it("treats missing visible as true", () => {
+    const specs = [{ id: "a", minZoom: 5 }];
+    applyZoomVisibility(specs, 6);
+    expect(specs[0].visible).toBe(true);
+  });
+});
+
+describe("zoomVisibilityKey", () => {
+  it("returns null when nothing is gated", () => {
+    expect(zoomVisibilityKey([{ id: "a" }, { id: "b" }], 5)).toBeNull();
+  });
+
+  it("fingerprints only gated specs and changes exactly when a gate flips", () => {
+    const specs = [
+      { id: "a", minZoom: 5 },
+      { id: "b" },
+      { id: "c", maxZoom: 8 },
+    ];
+    const k1 = zoomVisibilityKey(specs, 6); // a in, c in
+    const k2 = zoomVisibilityKey(specs, 7); // same states
+    const k3 = zoomVisibilityKey(specs, 9); // c flips out
+    expect(k1).toBe(k2);
+    expect(k1).not.toBe(k3);
+    expect(k1).toBe("a:1|c:1|");
+    expect(k3).toBe("a:1|c:0|");
+  });
+});

--- a/js/src/binary-buffer.js
+++ b/js/src/binary-buffer.js
@@ -1,0 +1,30 @@
+/**
+ * Normalize the anywidget binary payload to a standalone ArrayBuffer.
+ *
+ * anywidget delivers Bytes traitlets as a DataView. The underlying
+ * ArrayBuffer may be shared with a non-zero byteOffset, so the relevant
+ * slice must be copied into a standalone ArrayBuffer to ensure typed array
+ * constructors get correct offsets.
+ *
+ * @param {DataView|ArrayBuffer|{buffer: ArrayBuffer}} binaryData
+ * @returns {ArrayBuffer|null} standalone buffer, or null when unusable
+ */
+export function normalizeBinaryBuffer(binaryData) {
+  if (!binaryData) return null;
+  if (binaryData instanceof DataView) {
+    const src = new Uint8Array(binaryData.buffer, binaryData.byteOffset, binaryData.byteLength);
+    const copy = new ArrayBuffer(binaryData.byteLength);
+    new Uint8Array(copy).set(src);
+    return copy;
+  }
+  if (binaryData instanceof ArrayBuffer) {
+    return binaryData;
+  }
+  if (binaryData.buffer instanceof ArrayBuffer) {
+    const src = new Uint8Array(binaryData.buffer, binaryData.byteOffset || 0, binaryData.byteLength);
+    const copy = new ArrayBuffer(binaryData.byteLength);
+    new Uint8Array(copy).set(src);
+    return copy;
+  }
+  return null;
+}

--- a/js/src/binary-data.js
+++ b/js/src/binary-data.js
@@ -1,0 +1,73 @@
+/**
+ * Binary attribute reconstruction: applies Python-packed typed-array data
+ * to layer specs using deck.gl's native `data.attributes` format.
+ *
+ * Deliberately free of deck.gl imports so it stays unit-testable in Node.
+ */
+
+export const DTYPE_CONSTRUCTORS = {
+  float32: Float32Array,
+  float64: Float64Array,
+  uint8: Uint8Array,
+  uint16: Uint16Array,
+  uint32: Uint32Array,
+  int8: Int8Array,
+  int16: Int16Array,
+  int32: Int32Array,
+};
+
+/**
+ * Apply binary data to layer specs from a packed ArrayBuffer.
+ *
+ * @param {Array<Object>} specs - Layer specifications
+ * @param {ArrayBuffer} buffer - Packed binary buffer
+ * @param {Object} metadata - Describes layout: {layers: [{id, length, startIndices, attributes}]}
+ */
+export function applyBinaryData(specs, buffer, metadata) {
+  if (!metadata || !metadata.layers || !buffer || buffer.byteLength === 0) return;
+
+  const metaByLayer = {};
+  for (const lm of metadata.layers) {
+    metaByLayer[lm.id] = lm;
+  }
+
+  for (const spec of specs) {
+    const lm = metaByLayer[spec.id];
+    if (!lm) continue;
+
+    // Build startIndices typed array (only for variable-length layers like Polygon/Path)
+    let startIndices = undefined;
+    if (lm.startIndices) {
+      const SICtor = DTYPE_CONSTRUCTORS[lm.startIndices.dtype];
+      startIndices = new SICtor(
+        buffer,
+        lm.startIndices.offset,
+        lm.startIndices.byteLength / SICtor.BYTES_PER_ELEMENT
+      );
+    }
+
+    // Build attribute typed arrays
+    const attributes = {};
+    for (const [name, meta] of Object.entries(lm.attributes)) {
+      const Ctor = DTYPE_CONSTRUCTORS[meta.dtype];
+      attributes[name] = {
+        value: new Ctor(buffer, meta.offset, meta.byteLength / Ctor.BYTES_PER_ELEMENT),
+        size: meta.size,
+      };
+    }
+
+    spec.data = {
+      length: lm.length,
+      attributes,
+    };
+    if (startIndices) {
+      spec.data.startIndices = startIndices;
+    }
+    // Forward pre-packed tooltip strings for binary-mode tooltip lookup
+    if (lm.tooltips) {
+      spec._tooltips = lm.tooltips;
+    }
+    // Mark as binary so createLayer skips accessor resolution
+    spec._binary = true;
+  }
+}

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -7,7 +7,12 @@
 import maplibregl from "maplibre-gl";
 import maplibreCss from "maplibre-gl/dist/maplibre-gl.css";
 import { MapboxOverlay } from "@deck.gl/mapbox";
-import { createLayers, applyBinaryData } from "./layer-factory.js";
+import { createLayers } from "./layer-factory.js";
+import { applyBinaryData } from "./binary-data.js";
+import { normalizeBinaryBuffer } from "./binary-buffer.js";
+import { applyZoomVisibility, zoomVisibilityKey } from "./zoom-visibility.js";
+import { createPerfTracker } from "./perf-tracker.js";
+import { attachPickHandlers } from "./pick-events.js";
 
 /**
  * Inject MapLibre CSS into the document if not already present.
@@ -22,90 +27,6 @@ function ensureMaplibreCss() {
 }
 
 /**
- * FPS / performance metrics tracker.
- * Uses requestAnimationFrame to measure frame times and periodically
- * pushes metrics back to the Python model.
- */
-function createPerfTracker(model) {
-  const frameTimes = [];
-  const maxSamples = 60;
-  let lastTime = performance.now();
-  let lastPush = 0;
-  let animId = null;
-  let deckRef = null; // set externally to access deck.metrics
-
-  function tick(now) {
-    const dt = now - lastTime;
-    lastTime = now;
-    frameTimes.push(dt);
-    if (frameTimes.length > maxSamples) frameTimes.shift();
-
-    // Push metrics to Python every 500ms
-    if (now - lastPush > 500 && frameTimes.length > 5) {
-      lastPush = now;
-      const avg = frameTimes.reduce((a, b) => a + b, 0) / frameTimes.length;
-      const fps = 1000 / avg;
-      const min = Math.min(...frameTimes);
-      const max = Math.max(...frameTimes);
-
-      const metrics = {
-        fps: Math.round(fps * 10) / 10,
-        frameTimeAvg: Math.round(avg * 100) / 100,
-        frameTimeMin: Math.round(min * 100) / 100,
-        frameTimeMax: Math.round(max * 100) / 100,
-      };
-
-      // Try to get deck.gl internal metrics
-      try {
-        const dm = deckRef?.metrics;
-        if (dm) {
-          metrics.gpuTime = dm.gpuTime;
-          metrics.cpuTime = dm.cpuTime;
-          metrics.gpuTimePerFrame = dm.gpuTimePerFrame;
-          metrics.cpuTimePerFrame = dm.cpuTimePerFrame;
-          metrics.bufferMemory = dm.bufferMemory;
-          metrics.textureMemory = dm.textureMemory;
-        }
-      } catch (e) {
-        // deck metrics not available
-      }
-
-      model.set("perf_metrics", metrics);
-      model.save_changes();
-    }
-
-    animId = requestAnimationFrame(tick);
-  }
-
-  return {
-    start() { animId = requestAnimationFrame(tick); },
-    stop() { if (animId) cancelAnimationFrame(animId); },
-    setDeck(d) { deckRef = d; },
-  };
-}
-
-/**
- * Fold min/max zoom gating into each spec's `visible` prop.
- *
- * Preserves the user-supplied visible by stashing it once on `_userVisible`,
- * so repeated calls with a changing zoom are idempotent.
- */
-function applyZoomVisibility(specs, zoom) {
-  for (const spec of specs) {
-    const hasMin = spec.minZoom != null;
-    const hasMax = spec.maxZoom != null;
-    if (!hasMin && !hasMax) continue;
-    if (spec._userVisible === undefined) {
-      spec._userVisible = spec.visible !== false;
-    }
-    const inRange =
-      (!hasMin || zoom >= spec.minZoom) &&
-      (!hasMax || zoom <= spec.maxZoom);
-    spec.visible = spec._userVisible && inRange;
-  }
-}
-
-/**
  * Build layers from specs, applying binary data if available.
  */
 function buildLayers(model, map) {
@@ -113,27 +34,7 @@ function buildLayers(model, map) {
   const binaryMeta = model.get("binary_metadata") || {};
   const binaryData = model.get("binary_data");
 
-  // anywidget delivers Bytes traitlets as DataView.
-  // The underlying ArrayBuffer may be shared with a non-zero byteOffset,
-  // so we must copy the relevant slice into a standalone ArrayBuffer
-  // to ensure typed array constructors get correct offsets.
-  let buffer = null;
-  if (binaryData && binaryMeta.layers) {
-    if (binaryData instanceof DataView) {
-      const src = new Uint8Array(binaryData.buffer, binaryData.byteOffset, binaryData.byteLength);
-      const copy = new ArrayBuffer(binaryData.byteLength);
-      new Uint8Array(copy).set(src);
-      buffer = copy;
-    } else if (binaryData instanceof ArrayBuffer) {
-      buffer = binaryData;
-    } else if (binaryData && binaryData.buffer instanceof ArrayBuffer) {
-      const src = new Uint8Array(binaryData.buffer, binaryData.byteOffset || 0, binaryData.byteLength);
-      const copy = new ArrayBuffer(binaryData.byteLength);
-      new Uint8Array(copy).set(src);
-      buffer = copy;
-    }
-  }
-
+  const buffer = binaryMeta.layers ? normalizeBinaryBuffer(binaryData) : null;
   if (buffer && binaryMeta.layers) {
     applyBinaryData(specs, buffer, binaryMeta);
   }
@@ -218,19 +119,8 @@ async function render({ model, el }) {
   // Fires every animation frame during zoom; we only call setProps when at
   // least one gated layer's effective visibility actually flips.
   map.on("zoom", () => {
-    const specs = model.get("layer_specs") || [];
-    const zoom = map.getZoom();
-    let hasGated = false;
-    let key = "";
-    for (const s of specs) {
-      if (s.minZoom == null && s.maxZoom == null) continue;
-      hasGated = true;
-      const inRange =
-        (s.minZoom == null || zoom >= s.minZoom) &&
-        (s.maxZoom == null || zoom <= s.maxZoom);
-      key += `${s.id}:${inRange ? 1 : 0}|`;
-    }
-    if (!hasGated) return;
+    const key = zoomVisibilityKey(model.get("layer_specs") || [], map.getZoom());
+    if (key === null) return;
     if (key !== lastZoomVisibilityKey) {
       lastZoomVisibilityKey = key;
       overlay.setProps({ layers: buildLayers(model, map) });
@@ -280,29 +170,7 @@ async function render({ model, el }) {
   });
 
   // --- Click/hover event readback ---
-  // Gate on info.picked (deck.gl's canonical "something was picked" flag) so
-  // binary-packed layers emit events too — they don't populate info.object.
-  const pickPayload = (info) => ({
-    object: info.object ?? null,
-    coordinate: info.coordinate,
-    layer_id: info.layer ? info.layer.id : null,
-    index: info.index,
-  });
-  overlay.setProps({
-    ...overlay.props,
-    onClick: (info) => {
-      if (info && info.picked) {
-        model.set("click_info", pickPayload(info));
-        model.save_changes();
-      }
-    },
-    onHover: (info) => {
-      if (info && info.picked) {
-        model.set("hover_info", pickPayload(info));
-        model.save_changes();
-      }
-    },
-  });
+  attachPickHandlers(overlay, model);
 
   // --- Cleanup ---
   return () => {

--- a/js/src/layer-factory.js
+++ b/js/src/layer-factory.js
@@ -43,73 +43,6 @@ import { SimpleMeshLayer, ScenegraphLayer } from "@deck.gl/mesh-layers";
 
 import { resolveAccessors } from "./accessor-resolver.js";
 
-const DTYPE_CONSTRUCTORS = {
-  float32: Float32Array,
-  float64: Float64Array,
-  uint8: Uint8Array,
-  uint16: Uint16Array,
-  uint32: Uint32Array,
-  int8: Int8Array,
-  int16: Int16Array,
-  int32: Int32Array,
-};
-
-/**
- * Apply binary data to layer specs from a packed ArrayBuffer.
- *
- * @param {Array<Object>} specs - Layer specifications
- * @param {ArrayBuffer} buffer - Packed binary buffer
- * @param {Object} metadata - Describes layout: {layers: [{id, length, startIndices, attributes}]}
- */
-export function applyBinaryData(specs, buffer, metadata) {
-  if (!metadata || !metadata.layers || !buffer || buffer.byteLength === 0) return;
-
-  const metaByLayer = {};
-  for (const lm of metadata.layers) {
-    metaByLayer[lm.id] = lm;
-  }
-
-  for (const spec of specs) {
-    const lm = metaByLayer[spec.id];
-    if (!lm) continue;
-
-    // Build startIndices typed array (only for variable-length layers like Polygon/Path)
-    let startIndices = undefined;
-    if (lm.startIndices) {
-      const SICtor = DTYPE_CONSTRUCTORS[lm.startIndices.dtype];
-      startIndices = new SICtor(
-        buffer,
-        lm.startIndices.offset,
-        lm.startIndices.byteLength / SICtor.BYTES_PER_ELEMENT
-      );
-    }
-
-    // Build attribute typed arrays
-    const attributes = {};
-    for (const [name, meta] of Object.entries(lm.attributes)) {
-      const Ctor = DTYPE_CONSTRUCTORS[meta.dtype];
-      attributes[name] = {
-        value: new Ctor(buffer, meta.offset, meta.byteLength / Ctor.BYTES_PER_ELEMENT),
-        size: meta.size,
-      };
-    }
-
-    spec.data = {
-      length: lm.length,
-      attributes,
-    };
-    if (startIndices) {
-      spec.data.startIndices = startIndices;
-    }
-    // Forward pre-packed tooltip strings for binary-mode tooltip lookup
-    if (lm.tooltips) {
-      spec._tooltips = lm.tooltips;
-    }
-    // Mark as binary so createLayer skips accessor resolution
-    spec._binary = true;
-  }
-}
-
 /**
  * Registry mapping layer type names to deck.gl layer classes.
  */
@@ -160,8 +93,9 @@ const LAYER_REGISTRY = {
  * @returns {Layer} A deck.gl layer instance
  */
 export function createLayer(spec) {
-  // minZoom/maxZoom are handled by applyZoomVisibility in index.js — peel them
-  // off (along with the stashed _userVisible) so deck.gl doesn't see them.
+  // minZoom/maxZoom are handled by applyZoomVisibility in zoom-visibility.js —
+  // peel them off (along with the stashed _userVisible) so deck.gl doesn't
+  // see them.
   const {
     type,
     _binary,

--- a/js/src/perf-tracker.js
+++ b/js/src/perf-tracker.js
@@ -1,0 +1,62 @@
+/**
+ * FPS / performance metrics tracker.
+ * Uses requestAnimationFrame to measure frame times and periodically
+ * pushes metrics back to the Python model.
+ */
+export function createPerfTracker(model) {
+  const frameTimes = [];
+  const maxSamples = 60;
+  let lastTime = performance.now();
+  let lastPush = 0;
+  let animId = null;
+  let deckRef = null; // set externally to access deck.metrics
+
+  function tick(now) {
+    const dt = now - lastTime;
+    lastTime = now;
+    frameTimes.push(dt);
+    if (frameTimes.length > maxSamples) frameTimes.shift();
+
+    // Push metrics to Python every 500ms
+    if (now - lastPush > 500 && frameTimes.length > 5) {
+      lastPush = now;
+      const avg = frameTimes.reduce((a, b) => a + b, 0) / frameTimes.length;
+      const fps = 1000 / avg;
+      const min = Math.min(...frameTimes);
+      const max = Math.max(...frameTimes);
+
+      const metrics = {
+        fps: Math.round(fps * 10) / 10,
+        frameTimeAvg: Math.round(avg * 100) / 100,
+        frameTimeMin: Math.round(min * 100) / 100,
+        frameTimeMax: Math.round(max * 100) / 100,
+      };
+
+      // Try to get deck.gl internal metrics
+      try {
+        const dm = deckRef?.metrics;
+        if (dm) {
+          metrics.gpuTime = dm.gpuTime;
+          metrics.cpuTime = dm.cpuTime;
+          metrics.gpuTimePerFrame = dm.gpuTimePerFrame;
+          metrics.cpuTimePerFrame = dm.cpuTimePerFrame;
+          metrics.bufferMemory = dm.bufferMemory;
+          metrics.textureMemory = dm.textureMemory;
+        }
+      } catch (e) {
+        // deck metrics not available
+      }
+
+      model.set("perf_metrics", metrics);
+      model.save_changes();
+    }
+
+    animId = requestAnimationFrame(tick);
+  }
+
+  return {
+    start() { animId = requestAnimationFrame(tick); },
+    stop() { if (animId) cancelAnimationFrame(animId); },
+    setDeck(d) { deckRef = d; },
+  };
+}

--- a/js/src/pick-events.js
+++ b/js/src/pick-events.js
@@ -1,0 +1,38 @@
+/**
+ * Click/hover pick-event readback: JS -> Python.
+ */
+
+/** Shape a deck.gl picking info object into the payload Python receives. */
+export function pickPayload(info) {
+  return {
+    object: info.object ?? null,
+    coordinate: info.coordinate,
+    layer_id: info.layer ? info.layer.id : null,
+    index: info.index,
+  };
+}
+
+/**
+ * Attach onClick/onHover handlers to the overlay that push pick events to
+ * the model.
+ *
+ * Gate on info.picked (deck.gl's canonical "something was picked" flag) so
+ * binary-packed layers emit events too — they don't populate info.object.
+ */
+export function attachPickHandlers(overlay, model) {
+  overlay.setProps({
+    ...overlay.props,
+    onClick: (info) => {
+      if (info && info.picked) {
+        model.set("click_info", pickPayload(info));
+        model.save_changes();
+      }
+    },
+    onHover: (info) => {
+      if (info && info.picked) {
+        model.set("hover_info", pickPayload(info));
+        model.save_changes();
+      }
+    },
+  });
+}

--- a/js/src/zoom-visibility.js
+++ b/js/src/zoom-visibility.js
@@ -1,0 +1,49 @@
+/**
+ * Zoom-gated layer visibility.
+ *
+ * Python emits `minZoom`/`maxZoom` on layer specs; these are widget-side
+ * gates folded into each spec's `visible` prop (deck.gl never sees them —
+ * the layer factory peels them off).
+ */
+
+/** True when the current zoom is inside the spec's [minZoom, maxZoom] range. */
+export function isInZoomRange(spec, zoom) {
+  return (
+    (spec.minZoom == null || zoom >= spec.minZoom) &&
+    (spec.maxZoom == null || zoom <= spec.maxZoom)
+  );
+}
+
+/**
+ * Fold min/max zoom gating into each spec's `visible` prop.
+ *
+ * Preserves the user-supplied visible by stashing it once on `_userVisible`,
+ * so repeated calls with a changing zoom are idempotent.
+ */
+export function applyZoomVisibility(specs, zoom) {
+  for (const spec of specs) {
+    if (spec.minZoom == null && spec.maxZoom == null) continue;
+    if (spec._userVisible === undefined) {
+      spec._userVisible = spec.visible !== false;
+    }
+    spec.visible = spec._userVisible && isInZoomRange(spec, zoom);
+  }
+}
+
+/**
+ * Compact fingerprint of every gated spec's in-range state at this zoom.
+ *
+ * Returns null when no spec is zoom-gated. The zoom event handler compares
+ * consecutive keys so it only rebuilds layers when at least one gated
+ * layer's effective visibility actually flips.
+ */
+export function zoomVisibilityKey(specs, zoom) {
+  let hasGated = false;
+  let key = "";
+  for (const s of specs) {
+    if (s.minZoom == null && s.maxZoom == null) continue;
+    hasGated = true;
+    key += `${s.id}:${isInZoomRange(s, zoom) ? 1 : 0}|`;
+  }
+  return hasGated ? key : null;
+}


### PR DESCRIPTION
Closes #12, closes #10.

**Chain position: 4/20 — stacked on #40 (chore/js-deps).**

## What

**Module split (#12).** `js/src/index.js` was one 315-line `render()`. Extracted:
- `zoom-visibility.js` — `isInZoomRange` / `applyZoomVisibility` / `zoomVisibilityKey`. This also removes the duplication where the min/max-zoom range test lived in both `applyZoomVisibility` and inline in the `map.on("zoom")` handler.
- `binary-buffer.js` — `normalizeBinaryBuffer`, the anywidget DataView → standalone-ArrayBuffer copy.
- `binary-data.js` — `applyBinaryData` + `DTYPE_CONSTRUCTORS`, moved out of `layer-factory.js` so the module has **no deck.gl imports** and runs under Node/vitest.
- `perf-tracker.js`, `pick-events.js` — verbatim extractions.

`index.js` is now orchestration only. Bundle behavior is unchanged (rebuilt cleanly, same size).

**vitest (#10).** 25 tests in `js/src/__tests__/`:
- zoom gating: inclusive bounds, one-sided bounds, `_userVisible` stash idempotency (user-hidden layer never resurrected), key fingerprint changes exactly when a gate flips
- binary buffer: DataView with non-zero byteOffset copied correctly, ArrayBuffer passthrough, typed-array subarray handling
- binary data: typed-array reconstruction with mixed dtypes/offsets, startIndices for variable-length layers, tooltip forwarding, `_binary` flag, no-op on empty buffer/missing metadata
- accessor resolution: column-string vs constant-string (TextLayer anchors), column lists, RGBA constants, per-row indexed arrays, non-accessor props untouched

CI now runs `npm test` before the bundle build.

## Verification

`npm test` → 25 passed; `npm run build` clean; Python suite (233) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MB6bkjREt8tm7UkFjrogki
