### PR TITLE
Fix Map.update_layer prop routing

### DIFF
--- a/src/deckgl_marimo/_base.py
+++ b/src/deckgl_marimo/_base.py
@@ -153,6 +153,13 @@ class BaseLayer:
         "basemap", "center", "zoom", "pitch", "bearing", "map_height",
     }
 
+    # Instance attributes assigned in __init__ (everything else the user
+    # passes lands in self._props). Map.update_layer routes on this set.
+    _FIELD_KEYS: ClassVar[frozenset[str]] = frozenset({
+        "id", "data", "visible", "opacity", "pickable", "auto_highlight",
+        "min_zoom", "max_zoom", "load_options", "fetch_headers", "use_binary",
+    })
+
     # Union of declared kwargs across this class and its ancestors. ``None``
     # on ``BaseLayer`` itself disables validation (catch-all behavior); every
     # subclass receives a concrete frozenset via ``__init_subclass__`` at

--- a/src/deckgl_marimo/_map.py
+++ b/src/deckgl_marimo/_map.py
@@ -228,16 +228,33 @@ class Map(anywidget.AnyWidget):
         layer_id
             The ``id`` of the layer to update.
         **props
-            Properties to update (snake_case).
+            Properties to update (snake_case). Validated against the
+            layer's declared props; unknown keys raise ``TypeError`` with
+            a "did you mean" suggestion.
         """
-        for layer in self._layers:
-            if layer.id == layer_id:
-                for key, value in props.items():
-                    if hasattr(layer, key):
-                        setattr(layer, key, value)
-                    else:
-                        layer._props[key] = value
-                break
+        layer = next((lyr for lyr in self._layers if lyr.id == layer_id), None)
+        if layer is None:
+            return
+
+        # Explicit routing — never getattr/hasattr on the layer, whose
+        # __getattr__ delegates to a lazily-created backing Map (a hasattr
+        # probe would instantiate a hidden widget and mis-route keys that
+        # happen to collide with Map traitlets, e.g. `zoom`).
+        map_keys = [k for k in props if k in layer._MAP_KEYS]
+        if map_keys:
+            raise ValueError(
+                f"{map_keys!r} are map-level settings for standalone layer "
+                "display and cannot be changed via update_layer(); set them "
+                "on the Map itself (e.g. map.zoom = 10)."
+            )
+        valid = layer._FIELD_KEYS | (layer._VALID_PROPS or frozenset())
+        _raise_for_unknown_props(type(layer).__name__, props, valid)
+
+        for key, value in props.items():
+            if key in layer._FIELD_KEYS:
+                setattr(layer, key, value)
+            else:
+                layer._props[key] = value
         self._sync_layers()
 
     def fit_bounds(self, bounds: list[list[float]]) -> None:

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -116,3 +116,49 @@ class TestAsWidgetWithoutMarimo:
         monkeypatch.setitem(sys.modules, "marimo", None)
         with pytest.raises(ImportError, match=r"deckgl-marimo\[marimo\]"):
             m.as_widget()
+
+
+class TestUpdateLayerRouting:
+    """update_layer routes explicitly and never touches the backing Map (#20)."""
+
+    def _map_with_layer(self):
+        layer = ScatterplotLayer(
+            id="pts", data=[{"lon": 0, "lat": 0}], get_position=["lon", "lat"]
+        )
+        return Map(layers=[layer]), layer
+
+    def test_spec_prop_roundtrips_into_to_spec(self):
+        m, layer = self._map_with_layer()
+        m.update_layer("pts", get_radius=42, radius_scale=2)
+        spec = layer.to_spec()
+        assert spec["getRadius"] == 42
+        assert spec["radiusScale"] == 2
+
+    def test_base_field_roundtrips_into_to_spec(self):
+        m, layer = self._map_with_layer()
+        m.update_layer("pts", visible=False, opacity=0.25)
+        assert layer.visible is False
+        spec = layer.to_spec()
+        assert spec["visible"] is False
+        assert spec["opacity"] == 0.25
+
+    def test_never_instantiates_backing_map(self):
+        m, layer = self._map_with_layer()
+        m.update_layer("pts", get_radius=1, visible=True, opacity=0.5)
+        assert layer._BaseLayer__map is None
+
+    def test_unknown_prop_raises_with_suggestion(self):
+        m, _layer = self._map_with_layer()
+        with pytest.raises(TypeError, match="get_radius"):
+            m.update_layer("pts", get_radiuss=5)
+
+    def test_map_level_key_raises_helpful_error(self):
+        m, layer = self._map_with_layer()
+        with pytest.raises(ValueError, match="map-level"):
+            m.update_layer("pts", zoom=10)
+        # and no dead attribute was set on the layer
+        assert "zoom" not in layer.__dict__
+
+    def test_missing_layer_is_a_noop(self):
+        m, _layer = self._map_with_layer()
+        m.update_layer("nope", get_radius=5)  # no raise, no change


### PR DESCRIPTION
Closes #20.

**Chain position: 6/20 — stacked on #42 (fix/polygon-binary).**

## What

`Map.update_layer()` routed props via `hasattr(layer, key)` — but `BaseLayer.__getattr__` delegates unknown attributes to a lazily-created backing Map, so:

1. `update_layer(id, zoom=10)` found Map's `zoom` traitlet via delegation, set a dead instance attribute on the layer, and **silently changed nothing**
2. Any key not on the layer **instantiated a hidden Map widget** as a side effect of the `hasattr` probe

Now:
- Explicit routing on a new `BaseLayer._FIELD_KEYS` set (the instance fields `__init__` assigns: `visible`, `opacity`, `data`, `use_binary`, …) → `setattr`; everything else → `_props`
- All keys validated against `_VALID_PROPS` with the existing difflib "did you mean" `TypeError`
- Map-level keys (`zoom`, `basemap`, `center`, …) raise a `ValueError` explaining they belong on the Map (`map.zoom = 10`), not `update_layer()`
- `update_layer` can no longer trigger `_get_map()` — verified by a test asserting the private backing-Map slot stays `None`

## Verification

Six new tests (spec-prop and base-field round-trips into `to_spec()`, no hidden Map, unknown-prop suggestion, map-level key error, missing-id no-op). Full suite 242 passed; ruff/pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MB6bkjREt8tm7UkFjrogki
