### PR TITLE
Rename zoom gating to visible_min_zoom/visible_max_zoom; unblock TileLayer

### DIFF
--- a/examples/14_zoom_visibility.py
+++ b/examples/14_zoom_visibility.py
@@ -56,7 +56,7 @@ def _(mo):
 def _(mo):
     label_min_zoom = mo.ui.slider(
         start=3, stop=10, step=0.5, value=5, show_value=True,
-        label="Label min_zoom",
+        label="Label visible_min_zoom",
     )
     mo.hstack([label_min_zoom], justify="start", gap=2)
     return (label_min_zoom,)
@@ -82,7 +82,7 @@ def _(cities, dgl, label_min_zoom):
         get_alignment_baseline="bottom",
         get_pixel_offset=[0, -12],
         billboard=True,
-        min_zoom=label_min_zoom.value,
+        visible_min_zoom=label_min_zoom.value,
     )
     return dots, labels
 

--- a/examples/15_polygon_zoom_visibility.py
+++ b/examples/15_polygon_zoom_visibility.py
@@ -82,7 +82,7 @@ def _(crossover, dgl, neighborhoods, region):
         line_width_min_pixels=2,
         stroked=True,
         filled=True,
-        max_zoom=crossover.value,
+        visible_max_zoom=crossover.value,
     )
     neighborhood_layer = dgl.PolygonLayer(
         data=neighborhoods,
@@ -91,7 +91,7 @@ def _(crossover, dgl, neighborhoods, region):
         get_line_color=[255, 255, 255],
         get_line_width=2,
         line_width_min_pixels=1,
-        min_zoom=crossover.value,
+        visible_min_zoom=crossover.value,
     )
     return neighborhood_layer, region_layer
 

--- a/js/src/__tests__/zoom-visibility.test.js
+++ b/js/src/__tests__/zoom-visibility.test.js
@@ -8,7 +8,7 @@ describe("isInZoomRange", () => {
   });
 
   it("applies inclusive min and max bounds", () => {
-    const spec = { minZoom: 5, maxZoom: 10 };
+    const spec = { visibleMinZoom: 5, visibleMaxZoom: 10 };
     expect(isInZoomRange(spec, 4.99)).toBe(false);
     expect(isInZoomRange(spec, 5)).toBe(true);
     expect(isInZoomRange(spec, 10)).toBe(true);
@@ -16,10 +16,10 @@ describe("isInZoomRange", () => {
   });
 
   it("supports one-sided bounds", () => {
-    expect(isInZoomRange({ minZoom: 8 }, 7)).toBe(false);
-    expect(isInZoomRange({ minZoom: 8 }, 9)).toBe(true);
-    expect(isInZoomRange({ maxZoom: 8 }, 7)).toBe(true);
-    expect(isInZoomRange({ maxZoom: 8 }, 9)).toBe(false);
+    expect(isInZoomRange({ visibleMinZoom: 8 }, 7)).toBe(false);
+    expect(isInZoomRange({ visibleMinZoom: 8 }, 9)).toBe(true);
+    expect(isInZoomRange({ visibleMaxZoom: 8 }, 7)).toBe(true);
+    expect(isInZoomRange({ visibleMaxZoom: 8 }, 9)).toBe(false);
   });
 });
 
@@ -32,7 +32,7 @@ describe("applyZoomVisibility", () => {
   });
 
   it("gates visibility by zoom range", () => {
-    const specs = [{ id: "a", visible: true, minZoom: 5 }];
+    const specs = [{ id: "a", visible: true, visibleMinZoom: 5 }];
     applyZoomVisibility(specs, 3);
     expect(specs[0].visible).toBe(false);
     applyZoomVisibility(specs, 6);
@@ -40,7 +40,7 @@ describe("applyZoomVisibility", () => {
   });
 
   it("is idempotent: repeated calls never lose the user-supplied visible", () => {
-    const specs = [{ id: "a", visible: false, minZoom: 5 }];
+    const specs = [{ id: "a", visible: false, visibleMinZoom: 5 }];
     applyZoomVisibility(specs, 6);
     expect(specs[0].visible).toBe(false); // user said hidden — stays hidden in range
     applyZoomVisibility(specs, 3);
@@ -50,7 +50,7 @@ describe("applyZoomVisibility", () => {
   });
 
   it("treats missing visible as true", () => {
-    const specs = [{ id: "a", minZoom: 5 }];
+    const specs = [{ id: "a", visibleMinZoom: 5 }];
     applyZoomVisibility(specs, 6);
     expect(specs[0].visible).toBe(true);
   });
@@ -63,9 +63,9 @@ describe("zoomVisibilityKey", () => {
 
   it("fingerprints only gated specs and changes exactly when a gate flips", () => {
     const specs = [
-      { id: "a", minZoom: 5 },
+      { id: "a", visibleMinZoom: 5 },
       { id: "b" },
-      { id: "c", maxZoom: 8 },
+      { id: "c", visibleMaxZoom: 8 },
     ];
     const k1 = zoomVisibilityKey(specs, 6); // a in, c in
     const k2 = zoomVisibilityKey(specs, 7); // same states

--- a/js/src/layer-factory.js
+++ b/js/src/layer-factory.js
@@ -93,15 +93,15 @@ const LAYER_REGISTRY = {
  * @returns {Layer} A deck.gl layer instance
  */
 export function createLayer(spec) {
-  // minZoom/maxZoom are handled by applyZoomVisibility in zoom-visibility.js —
+  // visibleMinZoom/visibleMaxZoom are handled by applyZoomVisibility in zoom-visibility.js —
   // peel them off (along with the stashed _userVisible) so deck.gl doesn't
   // see them.
   const {
     type,
     _binary,
     _tooltips: _tt,
-    minZoom: _mz,
-    maxZoom: _mx,
+    visibleMinZoom: _mz,
+    visibleMaxZoom: _mx,
     _userVisible: _uv,
     ...props
   } = spec;

--- a/js/src/zoom-visibility.js
+++ b/js/src/zoom-visibility.js
@@ -1,16 +1,16 @@
 /**
  * Zoom-gated layer visibility.
  *
- * Python emits `minZoom`/`maxZoom` on layer specs; these are widget-side
+ * Python emits `visibleMinZoom`/`visibleMaxZoom` on layer specs; these are widget-side
  * gates folded into each spec's `visible` prop (deck.gl never sees them —
  * the layer factory peels them off).
  */
 
-/** True when the current zoom is inside the spec's [minZoom, maxZoom] range. */
+/** True when the current zoom is inside the spec's [visibleMinZoom, visibleMaxZoom] range. */
 export function isInZoomRange(spec, zoom) {
   return (
-    (spec.minZoom == null || zoom >= spec.minZoom) &&
-    (spec.maxZoom == null || zoom <= spec.maxZoom)
+    (spec.visibleMinZoom == null || zoom >= spec.visibleMinZoom) &&
+    (spec.visibleMaxZoom == null || zoom <= spec.visibleMaxZoom)
   );
 }
 
@@ -22,7 +22,7 @@ export function isInZoomRange(spec, zoom) {
  */
 export function applyZoomVisibility(specs, zoom) {
   for (const spec of specs) {
-    if (spec.minZoom == null && spec.maxZoom == null) continue;
+    if (spec.visibleMinZoom == null && spec.visibleMaxZoom == null) continue;
     if (spec._userVisible === undefined) {
       spec._userVisible = spec.visible !== false;
     }
@@ -41,7 +41,7 @@ export function zoomVisibilityKey(specs, zoom) {
   let hasGated = false;
   let key = "";
   for (const s of specs) {
-    if (s.minZoom == null && s.maxZoom == null) continue;
+    if (s.visibleMinZoom == null && s.visibleMaxZoom == null) continue;
     hasGated = true;
     key += `${s.id}:${isInZoomRange(s, zoom) ? 1 : 0}|`;
   }

--- a/src/deckgl_marimo/_base.py
+++ b/src/deckgl_marimo/_base.py
@@ -108,10 +108,10 @@ class BaseLayer:
         Whether the layer responds to pointer events.
     auto_highlight
         Whether to highlight the picked object.
-    min_zoom
+    visible_min_zoom
         Minimum zoom level (inclusive) at which the layer is visible.
         If ``None`` (default), no lower bound is applied.
-    max_zoom
+    visible_max_zoom
         Maximum zoom level (inclusive) at which the layer is visible.
         If ``None`` (default), no upper bound is applied.
     load_options
@@ -157,7 +157,7 @@ class BaseLayer:
     # passes lands in self._props). Map.update_layer routes on this set.
     _FIELD_KEYS: ClassVar[frozenset[str]] = frozenset({
         "id", "data", "visible", "opacity", "pickable", "auto_highlight",
-        "min_zoom", "max_zoom", "load_options", "fetch_headers", "use_binary",
+        "visible_min_zoom", "visible_max_zoom", "load_options", "fetch_headers", "use_binary",
     })
 
     # Union of declared kwargs across this class and its ancestors. ``None``
@@ -179,8 +179,8 @@ class BaseLayer:
         opacity: float = 1.0,
         pickable: bool = True,
         auto_highlight: bool = False,
-        min_zoom: float | None = None,
-        max_zoom: float | None = None,
+        visible_min_zoom: float | None = None,
+        visible_max_zoom: float | None = None,
         load_options: dict[str, Any] | None = None,
         fetch_headers: dict[str, str] | None = None,
         use_binary: bool = False,
@@ -202,8 +202,8 @@ class BaseLayer:
         self.opacity = opacity
         self.pickable = pickable
         self.auto_highlight = auto_highlight
-        self.min_zoom = min_zoom
-        self.max_zoom = max_zoom
+        self.visible_min_zoom = visible_min_zoom
+        self.visible_max_zoom = visible_max_zoom
         self.load_options = load_options
         self.fetch_headers = fetch_headers
         self.use_binary = use_binary
@@ -240,10 +240,10 @@ class BaseLayer:
             "autoHighlight": self.auto_highlight,
         }
 
-        if self.min_zoom is not None:
-            spec["minZoom"] = self.min_zoom
-        if self.max_zoom is not None:
-            spec["maxZoom"] = self.max_zoom
+        if self.visible_min_zoom is not None:
+            spec["visibleMinZoom"] = self.visible_min_zoom
+        if self.visible_max_zoom is not None:
+            spec["visibleMaxZoom"] = self.visible_max_zoom
 
         if self.data is not None and not self.use_binary:
             spec["data"] = prepare_data(self.data)
@@ -325,7 +325,7 @@ class BaseLayer:
         # Avoid infinite recursion for our own attributes
         if name.startswith("_BaseLayer") or name in (
             "id", "data", "visible", "opacity", "pickable",
-            "auto_highlight", "min_zoom", "max_zoom",
+            "auto_highlight", "visible_min_zoom", "visible_max_zoom",
             "load_options", "fetch_headers",
             "_props", "_map_kwargs", "LAYER_TYPE", "_MAP_KEYS",
         ):

--- a/src/deckgl_marimo/layers/_composite.py
+++ b/src/deckgl_marimo/layers/_composite.py
@@ -177,8 +177,8 @@ class DisplacementLayer(BaseLayer):
                 pickable=self.pickable,
                 auto_highlight=self.auto_highlight,
                 visible=self.visible,
-                min_zoom=self.min_zoom,
-                max_zoom=self.max_zoom,
+                visible_min_zoom=self.visible_min_zoom,
+                visible_max_zoom=self.visible_max_zoom,
             )
             specs.append(arc.to_spec())
 
@@ -193,8 +193,8 @@ class DisplacementLayer(BaseLayer):
                 opacity=self.opacity,
                 pickable=self.pickable,
                 visible=self.visible,
-                min_zoom=self.min_zoom,
-                max_zoom=self.max_zoom,
+                visible_min_zoom=self.visible_min_zoom,
+                visible_max_zoom=self.visible_max_zoom,
             )
             specs.append(origin_scatter.to_spec())
 
@@ -209,8 +209,8 @@ class DisplacementLayer(BaseLayer):
                 opacity=self.opacity,
                 pickable=self.pickable,
                 visible=self.visible,
-                min_zoom=self.min_zoom,
-                max_zoom=self.max_zoom,
+                visible_min_zoom=self.visible_min_zoom,
+                visible_max_zoom=self.visible_max_zoom,
             )
             specs.append(displaced_scatter.to_spec())
 
@@ -396,8 +396,8 @@ class EllipseLayer(BaseLayer):
             pickable=self.pickable,
             auto_highlight=self.auto_highlight,
             visible=self.visible,
-            min_zoom=self.min_zoom,
-            max_zoom=self.max_zoom,
+            visible_min_zoom=self.visible_min_zoom,
+            visible_max_zoom=self.visible_max_zoom,
         )
         specs.append(poly.to_spec())
 
@@ -412,8 +412,8 @@ class EllipseLayer(BaseLayer):
                 opacity=self.opacity,
                 pickable=self.pickable,
                 visible=self.visible,
-                min_zoom=self.min_zoom,
-                max_zoom=self.max_zoom,
+                visible_min_zoom=self.visible_min_zoom,
+                visible_max_zoom=self.visible_max_zoom,
             )
             specs.append(scatter.to_spec())
 

--- a/tests/test_base_layer.py
+++ b/tests/test_base_layer.py
@@ -1,5 +1,7 @@
 """Tests for BaseLayer and utility functions."""
 
+
+import pytest
 from deckgl_marimo._base import BaseLayer
 from deckgl_marimo.layers._core import GeoJsonLayer
 from deckgl_marimo._utils import to_camel_case, to_snake_case
@@ -73,32 +75,32 @@ class TestBaseLayer:
 
 class TestZoomVisibility:
     def test_min_zoom_in_spec(self):
-        layer = BaseLayer(min_zoom=5)
+        layer = BaseLayer(visible_min_zoom=5)
         spec = layer.to_spec()
-        assert spec["minZoom"] == 5
+        assert spec["visibleMinZoom"] == 5
 
     def test_max_zoom_in_spec(self):
-        layer = BaseLayer(max_zoom=15)
+        layer = BaseLayer(visible_max_zoom=15)
         spec = layer.to_spec()
-        assert spec["maxZoom"] == 15
+        assert spec["visibleMaxZoom"] == 15
 
     def test_both_zoom_bounds_in_spec(self):
-        layer = BaseLayer(min_zoom=5, max_zoom=15)
+        layer = BaseLayer(visible_min_zoom=5, visible_max_zoom=15)
         spec = layer.to_spec()
-        assert spec["minZoom"] == 5
-        assert spec["maxZoom"] == 15
+        assert spec["visibleMinZoom"] == 5
+        assert spec["visibleMaxZoom"] == 15
 
     def test_no_zoom_keys_by_default(self):
         layer = BaseLayer()
         spec = layer.to_spec()
-        assert "minZoom" not in spec
-        assert "maxZoom" not in spec
+        assert "visibleMinZoom" not in spec
+        assert "visibleMaxZoom" not in spec
 
     def test_fractional_zoom_bounds(self):
-        layer = BaseLayer(min_zoom=10.5, max_zoom=14.25)
+        layer = BaseLayer(visible_min_zoom=10.5, visible_max_zoom=14.25)
         spec = layer.to_spec()
-        assert spec["minZoom"] == 10.5
-        assert spec["maxZoom"] == 14.25
+        assert spec["visibleMinZoom"] == 10.5
+        assert spec["visibleMaxZoom"] == 14.25
 
 
 class TestLoadOptions:
@@ -160,3 +162,41 @@ class TestLoadOptions:
         assert spec["loadOptions"] == {
             "fetch": {"headers": {"X-API-Key": "abc123"}}
         }
+
+
+class TestZoomGatingRename:
+    """visible_min_zoom/visible_max_zoom gating vs deck.gl zoom props (#22)."""
+
+    def test_old_gating_names_raise_with_suggestion(self):
+        from deckgl_marimo.layers._core import ScatterplotLayer
+
+        with pytest.raises(TypeError, match="visible_min_zoom"):
+            ScatterplotLayer(min_zoom=5)
+        with pytest.raises(TypeError, match="visible_max_zoom"):
+            ScatterplotLayer(max_zoom=15)
+
+    def test_tile_layer_zoom_props_reach_the_spec(self):
+        import warnings
+
+        from deckgl_marimo.layers._geo import TileLayer
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")  # experimental warning
+            layer = TileLayer(min_zoom=2, max_zoom=18)
+        spec = layer.to_spec()
+        # Real deck.gl tile-fetch bounds — no longer consumed by gating
+        assert spec["minZoom"] == 2
+        assert spec["maxZoom"] == 18
+        assert "visibleMinZoom" not in spec
+
+    def test_gating_and_tile_zoom_coexist(self):
+        import warnings
+
+        from deckgl_marimo.layers._geo import TileLayer
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            layer = TileLayer(min_zoom=2, max_zoom=18, visible_min_zoom=4)
+        spec = layer.to_spec()
+        assert spec["minZoom"] == 2
+        assert spec["visibleMinZoom"] == 4

--- a/tests/test_layers/test_composite.py
+++ b/tests/test_layers/test_composite.py
@@ -135,11 +135,11 @@ class TestDisplacementLayer:
             assert spec["data"] == SAMPLE_DATA
 
     def test_zoom_bounds_propagate(self):
-        specs = self._make(min_zoom=8, max_zoom=14).to_specs()
+        specs = self._make(visible_min_zoom=8, visible_max_zoom=14).to_specs()
         assert len(specs) == 3
         for spec in specs:
-            assert spec["minZoom"] == 8
-            assert spec["maxZoom"] == 14
+            assert spec["visibleMinZoom"] == 8
+            assert spec["visibleMaxZoom"] == 14
 
 
 # =====================================================================
@@ -378,8 +378,8 @@ class TestEllipseLayer:
             self._make(num_vertices=2)
 
     def test_zoom_bounds_propagate(self):
-        specs = self._make(show_center_dots=True, min_zoom=8, max_zoom=14).to_specs()
+        specs = self._make(show_center_dots=True, visible_min_zoom=8, visible_max_zoom=14).to_specs()
         assert len(specs) == 2
         for spec in specs:
-            assert spec["minZoom"] == 8
-            assert spec["maxZoom"] == 14
+            assert spec["visibleMinZoom"] == 8
+            assert spec["visibleMaxZoom"] == 14

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -81,10 +81,10 @@ class TestMapLayerManagement:
             get_position=["lon", "lat"],
         )
         m = Map(layers=[layer])
-        assert "minZoom" not in m.layer_specs[0]
-        m.update_layer("test-layer", min_zoom=10, max_zoom=16)
-        assert m.layer_specs[0]["minZoom"] == 10
-        assert m.layer_specs[0]["maxZoom"] == 16
+        assert "visibleMinZoom" not in m.layer_specs[0]
+        m.update_layer("test-layer", visible_min_zoom=10, visible_max_zoom=16)
+        assert m.layer_specs[0]["visibleMinZoom"] == 10
+        assert m.layer_specs[0]["visibleMaxZoom"] == 16
 
     def test_layers_property(self):
         layer = ScatterplotLayer(data=[{"lon": 1, "lat": 2}], get_position=["lon", "lat"])


### PR DESCRIPTION
Closes #22.

**Chain position: 7/20 — stacked on #43 (fix/update-layer-routing).** ⚠️ Breaking.

## What

`BaseLayer`'s `min_zoom`/`max_zoom` widget-side visibility gates collided with genuine deck.gl props. `TileLayer(min_zoom=, max_zoom=)` are real tile-fetch bounds, but the base class consumed them as gates and the JS factory peeled `minZoom`/`maxZoom` off **every** spec before deck.gl saw them — TileLayer's tile-range control was silently reinterpreted as show/hide gating.

- Gating renamed to `visible_min_zoom`/`visible_max_zoom` (spec keys `visibleMinZoom`/`visibleMaxZoom`) — the exact naming deckgl_dash settled on for the same feature (its #38)
- JS `zoom-visibility.js` + `layer-factory.js` now peel only the new keys; `minZoom`/`maxZoom` pass through to deck.gl untouched
- Composite layers (Displacement/Ellipse) propagate the renamed gates to their sub-layers
- Old names raise the difflib "did you mean" `TypeError` (suggesting the new names)
- Examples `14_zoom_visibility.py` / `15_polygon_zoom_visibility.py` updated

## Breaking

`min_zoom=`/`max_zoom=` as visibility gates now raise; switch to `visible_min_zoom=`/`visible_max_zoom=`. On `TileLayer` (experimental), `min_zoom`/`max_zoom` change meaning — they now reach deck.gl as tile bounds, which is what the deck.gl docs say they do.

## Verification

New tests: old names raise with suggestion; TileLayer zoom props reach the spec; gating + tile bounds coexist on one layer. Full suite 245 passed; vitest 25 passed (gating tests renamed); ruff/pyright clean; bundle rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MB6bkjREt8tm7UkFjrogki
