### PR TITLE
API consistency: promote 3 core layers, public pack_binary, Map.set_layers, README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/kihaji/deckgl-marimo/blob/main/examples/hexagon_example.py)
 
-Interactive [deck.gl](https://deck.gl) visualization library for [marimo](https://marimo.io) notebooks. Render GPU-accelerated maps with 33 layer types, powered by [MapLibre GL](https://maplibre.org) and [anywidget](https://anywidget.dev).
+Interactive [deck.gl](https://deck.gl) visualization library for [marimo](https://marimo.io) notebooks. Render GPU-accelerated maps with 15 fully tested layer types (plus experimental access to the full deck.gl catalog), powered by [MapLibre GL](https://maplibre.org) and [anywidget](https://anywidget.dev).
 
 ## Features
 
-- **12 deck.gl layer types** — scatter plots, hexagonal bins, heatmaps, arcs, paths, polygons, GeoJSON, 3D columns, lines, point clouds, and more
+- **15 fully tested layer types** — scatter plots, hexagonal bins, heatmaps, arcs, paths, polygons, GeoJSON, 3D columns, lines, point clouds, and more — plus 17 experimental layers covering the rest of the deck.gl catalog
 - **Binary data transfer** — bypass JSON serialization for large datasets (30x faster, 4x smaller payloads)
 - **Multi-layer maps** — compose multiple layers on a single map
 - **Standalone layers** — display any layer directly without explicit map setup
@@ -101,15 +101,15 @@ widget = mo.ui.anywidget(map_widget)
 widget
 
 # Cell 4 — update layers reactively (re-executes when slider changes)
-map_widget.layer_specs = [
+map_widget.set_layers([
     dgl.HexagonLayer(
         data=df,
         get_position=["lon", "lat"],
         radius=radius.value,
         extruded=True,
         elevation_scale=250,
-    ).to_spec()
-]
+    )
+])
 
 # Cell 5 — viewport readback
 vp = widget.value.get("viewport", {})
@@ -197,7 +197,7 @@ layer = dgl.ScatterplotLayer(
 
 ```python
 import numpy as np
-from deckgl_marimo._binary import pack_binary
+from deckgl_marimo import pack_binary
 
 # Prepare arrays
 positions = np.column_stack([lons, lats]).astype(np.float32)
@@ -288,7 +288,7 @@ headers take precedence.
 
 ## Available layers
 
-### Fully tested (12)
+### Fully tested (15)
 
 | Layer | Use case | Binary support |
 |-------|----------|----------------|
@@ -297,6 +297,7 @@ headers take precedence.
 | `ArcLayer` | Origin-destination flows | Yes |
 | `PathLayer` | Routes, trajectories | Yes |
 | `PolygonLayer` | Filled regions | Yes |
+| `SolidPolygonLayer` | Filled regions without stroke (fastest polygons) | Yes |
 | `IconLayer` | Marker icons | — |
 | `TextLayer` | Labels | — |
 | `ColumnLayer` | 3D bars on map | Yes |
@@ -304,12 +305,12 @@ headers take precedence.
 | `HeatmapLayer` | Density visualization | — |
 | `LineLayer` | Straight lines between point pairs | Yes |
 | `PointCloudLayer` | 3D point clouds (LiDAR, etc.) | Yes |
+| `DisplacementLayer` | Origin vs reported-position arcs + dots (composite) | — |
+| `EllipseLayer` | Ellipses from center/axes/orientation (composite) | — |
 
-`LineLayer` and `PointCloudLayer` are newly exported experimental layers.
+### Experimental (17)
 
-### Experimental (21+)
-
-All additional deck.gl layers are available as experimental stubs via `deckgl_marimo.layers`:
+All additional deck.gl layers are available as experimental stubs via `deckgl_marimo.layers` (they emit a warning on construction and may not be fully tested):
 
 ```python
 from deckgl_marimo.layers import TripsLayer, MVTLayer, H3HexagonLayer, ContourLayer
@@ -330,7 +331,23 @@ dgl.Map(basemap="https://my-tileserver.example.com/style.json")
 
 ### `Content-Length` errors in the marimo console
 
-This is fixed in Marimo >= 0.22.0 please update to that.
+Fixed in marimo >= 0.22.0 — update marimo.
+
+### Map flashes black / camera resets when a slider moves
+
+The `Map` widget is being recreated on every reactive run. Create the
+`Map` in a cell with **no** slider dependencies and update layers from a
+separate cell with `map_widget.set_layers([...])` — see
+[Reactive controls](#reactive-controls) above. Assigning
+`map_widget.layer_specs` directly also works for JSON layers, but skips
+binary re-packing; prefer `set_layers`.
+
+### Blank map / WebGL errors on WSL or headless environments
+
+deck.gl requires WebGL2. In WSL, make sure your browser has hardware
+acceleration enabled (check `chrome://gpu` or https://webglreport.com).
+For headless Chromium testing, launch with
+`--use-gl=angle --use-angle=swiftshader --enable-unsafe-swiftshader`.
 
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "deckgl-marimo"
 version = "0.6.1"
-description = "deck.gl visualization library for marimo notebooks — interactive maps with 33 layer types"
+description = "deck.gl visualization library for marimo notebooks — 15 fully tested layer types on MapLibre basemaps, plus experimental access to the full deck.gl catalog"
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"

--- a/src/deckgl_marimo/__init__.py
+++ b/src/deckgl_marimo/__init__.py
@@ -6,6 +6,7 @@ anywidget-based widgets with full marimo reactivity support.
 
 from deckgl_marimo._accessors import Accessor, ColorAccessor, PositionAccessor
 from deckgl_marimo._basemaps import Basemaps
+from deckgl_marimo._binary import pack_binary, pack_polygon_binary
 from deckgl_marimo._color_scale import ColorScale
 from deckgl_marimo._map import Map
 from deckgl_marimo._view_state import ViewState
@@ -46,6 +47,9 @@ __all__ = [
     "ViewState",
     "Basemaps",
     "ColorScale",
+    # Binary packing
+    "pack_binary",
+    "pack_polygon_binary",
     # Accessor type aliases
     "Accessor",
     "ColorAccessor",

--- a/src/deckgl_marimo/_map.py
+++ b/src/deckgl_marimo/_map.py
@@ -198,6 +198,24 @@ class Map(anywidget.AnyWidget):
         finally:
             self._resolving_pick = False
 
+    def set_layers(self, layers: list[BaseLayer]) -> None:
+        """Replace all layers on the map.
+
+        This is the recommended way to update layers reactively (e.g. in a
+        marimo cell that depends on slider values): it re-serializes the
+        layer specs *and* re-packs binary buffers in one call, unlike
+        assigning ``layer_specs`` directly, which silently skips binary
+        packing.
+
+        Parameters
+        ----------
+        layers
+            The new list of :class:`BaseLayer` instances. Replaces any
+            existing layers.
+        """
+        self._layers = list(layers)
+        self._sync_layers()
+
     def add_layer(self, layer: BaseLayer) -> None:
         """Add a layer to the map.
 

--- a/src/deckgl_marimo/layers/_core.py
+++ b/src/deckgl_marimo/layers/_core.py
@@ -1036,7 +1036,6 @@ class GridCellLayer(BaseLayer):
         super().__init__(data=data, **kwargs)
 
 
-@_experimental
 class LineLayer(BaseLayer):
     """Render straight lines between pairs of points."""
 
@@ -1139,7 +1138,6 @@ class LineLayer(BaseLayer):
         return meta, buf
 
 
-@_experimental
 class PointCloudLayer(BaseLayer):
     """Render a point cloud."""
 
@@ -1236,7 +1234,6 @@ class PointCloudLayer(BaseLayer):
         return meta, buf
 
 
-@_experimental
 class SolidPolygonLayer(BaseLayer):
     """Render solid polygons (no stroke, better performance than PolygonLayer)."""
 

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -162,3 +162,54 @@ class TestUpdateLayerRouting:
     def test_missing_layer_is_a_noop(self):
         m, _layer = self._map_with_layer()
         m.update_layer("nope", get_radius=5)  # no raise, no change
+
+
+class TestSetLayers:
+    """set_layers replaces layers and re-packs binary in one shot (#30)."""
+
+    def test_replaces_specs_and_binary(self):
+        np = pytest.importorskip("numpy")
+        m = Map()
+        assert m.layer_specs == []
+        layer = ScatterplotLayer(
+            id="bin",
+            data=[{"lon": 1.0, "lat": 2.0}, {"lon": 3.0, "lat": 4.0}],
+            get_position=["lon", "lat"],
+            use_binary=True,
+        )
+        m.set_layers([layer])
+        assert [s["id"] for s in m.layer_specs] == ["bin"]
+        assert m.binary_metadata["layers"][0]["id"] == "bin"
+        assert len(m.binary_data) > 0
+        pos = np.frombuffer(m.binary_data[:16], dtype=np.float32)
+        assert list(pos) == [1.0, 2.0, 3.0, 4.0]
+
+    def test_replaces_existing_layers(self):
+        a = ScatterplotLayer(id="a", data=[{"lon": 0, "lat": 0}], get_position=["lon", "lat"])
+        b = ScatterplotLayer(id="b", data=[{"lon": 1, "lat": 1}], get_position=["lon", "lat"])
+        m = Map(layers=[a])
+        m.set_layers([b])
+        assert [lyr.id for lyr in m.layers] == ["b"]
+        assert [s["id"] for s in m.layer_specs] == ["b"]
+
+
+class TestPromotedCoreLayers:
+    """Line/PointCloud/SolidPolygon are core — no experimental warning (#28)."""
+
+    def test_no_warning_on_construction(self):
+        import warnings
+
+        from deckgl_marimo import LineLayer, PointCloudLayer, SolidPolygonLayer
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            LineLayer()
+            PointCloudLayer()
+            SolidPolygonLayer()
+
+    def test_pack_binary_public(self):
+        import deckgl_marimo as dgl
+
+        assert dgl.pack_binary is not None
+        assert dgl.pack_polygon_binary is not None
+        assert "pack_binary" in dgl.__all__


### PR DESCRIPTION
Closes #28, closes #29, closes #30, closes #33.

**Chain position: 8/20 — stacked on #44 (fix/zoom-gating-rename).**

## What

- **Experimental/core contradiction resolved (#28):** `LineLayer`, `PointCloudLayer`, `SolidPolygonLayer` were exported top-level under "Core layers (fully tested)" yet decorated `@_experimental`, warning on every construction. They have tests and binary support — the decorator is gone.
- **Layer taxonomy settled (#28):** one story everywhere — **15 fully tested** (11 core + 2 aggregation + 2 composite) **+ 17 experimental** via `deckgl_marimo.layers`. The pyproject description ("33 layer types"), README intro ("33"), features bullet ("12"), and the layer table ("Fully tested (12)" with a contradictory footnote) previously each said something different. The table now lists all 15 including `SolidPolygonLayer`, `DisplacementLayer`, `EllipseLayer`.
- **`pack_binary` public (#29):** `pack_binary`/`pack_polygon_binary` re-exported at top level and in `__all__`; README's pre-built-numpy example now imports `from deckgl_marimo import pack_binary` instead of the private `_binary` module.
- **`Map.set_layers()` (#30):** the README's recommended reactive pattern was `map.layer_specs = [layer.to_spec()]`, which silently skips binary packing — binary layers broke under the documented pattern. `set_layers(layers)` replaces layers and re-serializes specs *and* binary buffers in one call; the README teaches it now, keeping `layer_specs` as the low-level escape hatch.
- **Troubleshooting expanded (#33):** three real entries — Content-Length (marimo >= 0.22), black-flash/camera-reset with the reactive-pattern fix, WebGL on WSL/headless (SwiftShader flags).

## Verification

New tests: `set_layers` round-trips specs + binary buffer contents (float32 positions verified by frombuffer) and replaces existing layers; promoted layers construct warning-free under `simplefilter("error")`; public exports present. Full suite 249 passed; ruff/pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MB6bkjREt8tm7UkFjrogki
