### PR TITLE
Implement real fit_bounds; add public compute_bounds

### DIFF
--- a/js/src/index.js
+++ b/js/src/index.js
@@ -156,6 +156,16 @@ async function render({ model, el }) {
     });
   }
 
+  // --- Fit-bounds requests from Python ---
+  const applyFitBounds = () => {
+    const req = model.get("fit_bounds_request");
+    if (req && req.bounds) {
+      map.fitBounds(req.bounds, { padding: req.padding ?? 20 });
+    }
+  };
+  model.on("change:fit_bounds_request", applyFitBounds);
+  applyFitBounds(); // honor a request made before first render
+
   // --- Viewport readback: JS -> Python ---
   map.on("moveend", () => {
     const center = map.getCenter();

--- a/src/deckgl_marimo/__init__.py
+++ b/src/deckgl_marimo/__init__.py
@@ -7,6 +7,7 @@ anywidget-based widgets with full marimo reactivity support.
 from deckgl_marimo._accessors import Accessor, ColorAccessor, PositionAccessor
 from deckgl_marimo._basemaps import Basemaps
 from deckgl_marimo._binary import pack_binary, pack_polygon_binary
+from deckgl_marimo._bounds import compute_bounds
 from deckgl_marimo._color_scale import ColorScale
 from deckgl_marimo._map import Map
 from deckgl_marimo._view_state import ViewState
@@ -50,6 +51,8 @@ __all__ = [
     # Binary packing
     "pack_binary",
     "pack_polygon_binary",
+    # Bounds
+    "compute_bounds",
     # Accessor type aliases
     "Accessor",
     "ColorAccessor",

--- a/src/deckgl_marimo/_bounds.py
+++ b/src/deckgl_marimo/_bounds.py
@@ -1,0 +1,118 @@
+"""Geographic bounds computation for :meth:`Map.fit_bounds`.
+
+``compute_bounds`` extracts a ``[[west, south], [east, north]]`` box from a
+variety of inputs — point lists, path/polygon dicts, GeoJSON
+(FeatureCollection, Feature, or geometry), and DataFrames (via the
+``position`` column pair) — by recursively collecting ``[lon, lat]`` pairs.
+
+Ported from deckgl_dash's ``bounds.py``.
+
+Example:
+    >>> compute_bounds([{"position": [-122.4, 37.8]}, {"position": [-122.3, 37.9]}])
+    [[-122.4, 37.8], [-122.3, 37.9]]
+    >>> m.fit_bounds(compute_bounds(df, position=["lon", "lat"]), padding=40)
+"""
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from deckgl_marimo._data import materialize_rows
+
+_Number = (int, float)
+# Keys that hold coordinates in common deck.gl data shapes and GeoJSON.
+_COORD_KEYS = (
+    "path", "polygon", "position", "contour",
+    "sourcePosition", "targetPosition", "source_position", "target_position",
+    "from", "to",
+)
+
+
+def _is_point(x: Any) -> bool:
+    """True if x is a [lon, lat(, ...)] coordinate pair (bool excluded — bool is an int subclass)."""
+    return (
+        isinstance(x, (list, tuple)) and len(x) >= 2
+        and isinstance(x[0], _Number) and not isinstance(x[0], bool)
+        and isinstance(x[1], _Number) and not isinstance(x[1], bool)
+    )
+
+
+def _walk(obj: Any, out: list[tuple[float, float]]) -> None:
+    """Recursively collect [lon, lat] pairs from arbitrary nested coordinate structures."""
+    if obj is None:
+        return
+    if _is_point(obj):
+        out.append((float(obj[0]), float(obj[1])))
+        return
+    if isinstance(obj, (list, tuple)):
+        for item in obj:
+            _walk(item, out)
+        return
+    if isinstance(obj, dict):
+        if "features" in obj:
+            _walk(obj["features"], out)
+        if "geometry" in obj:
+            _walk(obj["geometry"], out)
+        if "coordinates" in obj:
+            _walk(obj["coordinates"], out)
+        for key in _COORD_KEYS:
+            if key in obj:
+                _walk(obj[key], out)
+
+
+def compute_bounds(
+    data: Any,
+    *,
+    position: list[str] | None = None,
+    get_coordinates: Callable[[Any], Any] | None = None,
+) -> list[list[float]]:
+    """Compute ``[[west, south], [east, north]]`` enclosing all coordinates in ``data``.
+
+    Parameters
+    ----------
+    data
+        A GeoJSON dict (FeatureCollection/Feature/geometry), a list of items
+        (each a ``[lon, lat]`` pair, a dict with ``coordinates``/``path``/
+        ``polygon``/``position``, or a GeoJSON Feature), or any tabular data
+        the library accepts (DataFrame, DuckDB relation, ...) when combined
+        with ``position``.
+    position
+        Column names for longitude and latitude, e.g. ``["lon", "lat"]`` —
+        the same form layer ``get_position`` accessors take. Use for
+        tabular data whose coordinates live in plain columns.
+    get_coordinates
+        Optional accessor mapping each item to its coordinate(s); use when
+        coordinates live under a non-standard key.
+
+    Returns
+    -------
+    list[list[float]]
+        ``[[west, south], [east, north]]``.
+
+    Raises
+    ------
+    ValueError
+        If no coordinates are found.
+    """
+    points: list[tuple[float, float]] = []
+    if position is not None:
+        rows = materialize_rows(data)
+        if rows is None:
+            raise ValueError(
+                "compute_bounds: cannot materialize rows from this data; "
+                "position= requires concrete tabular data (not a URL)."
+            )
+        lon_col, lat_col = position[0], position[1]
+        _walk([[row[lon_col], row[lat_col]] for row in rows], points)
+    elif get_coordinates is not None:
+        items = data["features"] if isinstance(data, dict) and "features" in data else data
+        for item in items:
+            _walk(get_coordinates(item), points)
+    else:
+        _walk(data, points)
+
+    if not points:
+        raise ValueError("compute_bounds: no coordinates found in data")
+
+    lons = [p[0] for p in points]
+    lats = [p[1] for p in points]
+    return [[min(lons), min(lats)], [max(lons), max(lats)]]

--- a/src/deckgl_marimo/_map.py
+++ b/src/deckgl_marimo/_map.py
@@ -85,6 +85,11 @@ class Map(anywidget.AnyWidget):
     binary_data = traitlets.Bytes(b"").tag(sync=True)
     binary_metadata = traitlets.Dict({}).tag(sync=True)
 
+    # One-shot fit-bounds request applied by the JS side via map.fitBounds.
+    # Carries a sequence number so repeated calls with identical bounds
+    # still fire a change event.
+    fit_bounds_request = traitlets.Dict({}).tag(sync=True)
+
     # Read-back from JS (JS -> Python)
     viewport = traitlets.Dict({}).tag(sync=True)
     click_info = traitlets.Dict({}).tag(sync=True)
@@ -109,6 +114,7 @@ class Map(anywidget.AnyWidget):
             _raise_for_unknown_props(type(self).__name__, kwargs, self._VALID_KWARGS)
         self._layers: list[BaseLayer] = list(layers or [])
         self._resolving_pick = False
+        self._fit_bounds_seq = 0
         specs = [spec for layer in self._layers for spec in layer.to_specs()]
         style = Basemaps.resolve(basemap)
 
@@ -275,17 +281,44 @@ class Map(anywidget.AnyWidget):
                 layer._props[key] = value
         self._sync_layers()
 
-    def fit_bounds(self, bounds: list[list[float]]) -> None:
-        """Set the view to fit the given bounds.
+    def fit_bounds(self, bounds: list[list[float]], *, padding: int = 20) -> None:
+        """Fit the viewport to the given bounds.
+
+        The JS side applies an exact ``map.fitBounds(bounds, {padding})``.
+        The Python-side view traitlets are also set to the bounds center
+        and an approximate zoom so state is sane before/without a
+        rendered frontend.
+
+        Use :func:`deckgl_marimo.compute_bounds` to derive bounds from
+        layer data.
 
         Parameters
         ----------
         bounds
-            [[sw_longitude, sw_latitude], [ne_longitude, ne_latitude]]
+            [[west, south], [east, north]] in degrees.
+        padding
+            Pixel padding around the bounds (applied by the JS side).
         """
+        import math
+
         sw, ne = bounds
         self.longitude = (sw[0] + ne[0]) / 2
         self.latitude = (sw[1] + ne[1]) / 2
+
+        # Approximate zoom: fit the larger angular span into a 360°-at-z0
+        # Mercator world. The JS fitBounds supersedes this with the exact
+        # pixel-based fit once rendered.
+        lon_span = max(abs(ne[0] - sw[0]), 1e-9)
+        lat_span = max(abs(ne[1] - sw[1]), 1e-9)
+        zoom = math.log2(360.0 / max(lon_span, lat_span * 2))
+        self.zoom = max(0.0, min(20.0, zoom))
+
+        self._fit_bounds_seq += 1
+        self.fit_bounds_request = {
+            "bounds": [list(sw), list(ne)],
+            "padding": padding,
+            "_seq": self._fit_bounds_seq,
+        }
 
     @property
     def layers(self) -> list[BaseLayer]:

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -1,0 +1,88 @@
+"""Tests for compute_bounds and Map.fit_bounds (#21)."""
+
+import pytest
+
+from deckgl_marimo import Map, compute_bounds
+
+
+class TestComputeBounds:
+    def test_point_pairs(self):
+        pts = [[-122.4, 37.8], [-122.3, 37.9], [-122.5, 37.7]]
+        assert compute_bounds(pts) == [[-122.5, 37.7], [-122.3, 37.9]]
+
+    def test_dicts_with_position_key(self):
+        data = [{"position": [-10, -5]}, {"position": [10, 5]}]
+        assert compute_bounds(data) == [[-10, -5], [10, 5]]
+
+    def test_dicts_with_path_key(self):
+        data = [{"path": [[0, 0], [1, 2]]}, {"path": [[-3, 4], [5, -6]]}]
+        assert compute_bounds(data) == [[-3, -6], [5, 4]]
+
+    def test_geojson_feature_collection(self):
+        fc = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [100.0, 0.5]},
+                    "properties": {},
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [[[101.0, 1.0], [102.0, 2.0], [101.5, 0.0], [101.0, 1.0]]],
+                    },
+                    "properties": {},
+                },
+            ],
+        }
+        assert compute_bounds(fc) == [[100.0, 0.0], [102.0, 2.0]]
+
+    def test_position_columns_from_rows(self):
+        data = [{"lon": -1.0, "lat": 2.0}, {"lon": 3.0, "lat": -4.0}]
+        assert compute_bounds(data, position=["lon", "lat"]) == [[-1.0, -4.0], [3.0, 2.0]]
+
+    def test_position_columns_from_dataframe(self):
+        pd = pytest.importorskip("pandas")
+        df = pd.DataFrame({"lon": [-1.0, 3.0], "lat": [2.0, -4.0]})
+        assert compute_bounds(df, position=["lon", "lat"]) == [[-1.0, -4.0], [3.0, 2.0]]
+
+    def test_get_coordinates_accessor(self):
+        data = [{"where": [7, 8]}, {"where": [9, 10]}]
+        bounds = compute_bounds(data, get_coordinates=lambda row: row["where"])
+        assert bounds == [[7, 8], [9, 10]]
+
+    def test_no_coordinates_raises(self):
+        with pytest.raises(ValueError, match="no coordinates"):
+            compute_bounds([{"name": "x"}])
+
+    def test_source_target_positions(self):
+        data = [{"source_position": [0, 0], "target_position": [10, 10]}]
+        assert compute_bounds(data) == [[0, 0], [10, 10]]
+
+
+class TestFitBounds:
+    def test_sets_center_zoom_and_request(self):
+        m = Map()
+        m.fit_bounds([[-10.0, -5.0], [10.0, 5.0]], padding=40)
+        assert m.longitude == 0.0
+        assert m.latitude == 0.0
+        assert m.zoom > 0
+        req = m.fit_bounds_request
+        assert req["bounds"] == [[-10.0, -5.0], [10.0, 5.0]]
+        assert req["padding"] == 40
+        assert req["_seq"] == 1
+
+    def test_repeated_identical_bounds_still_fire(self):
+        m = Map()
+        m.fit_bounds([[0, 0], [1, 1]])
+        first = m.fit_bounds_request["_seq"]
+        m.fit_bounds([[0, 0], [1, 1]])
+        assert m.fit_bounds_request["_seq"] == first + 1
+
+    def test_smaller_bounds_zoom_in_more(self):
+        m1, m2 = Map(), Map()
+        m1.fit_bounds([[-40, -20], [40, 20]])
+        m2.fit_bounds([[-1, -0.5], [1, 0.5]])
+        assert m2.zoom > m1.zoom


### PR DESCRIPTION
Closes #21.

**Chain position: 9/20 — stacked on #45 (feat/api-readme-consistency).**

## What

`Map.fit_bounds()` only centered the view — zoom was never computed, so it did not fit bounds.

- **Exact fit in JS:** new `fit_bounds_request` synced traitlet (`{bounds, padding, _seq}`); the frontend applies `map.fitBounds(bounds, {padding})` on change and once at render time, so a `fit_bounds()` call made before the widget is displayed still lands. `_seq` makes repeated identical requests re-fire (Dict traitlets don't emit on equal values).
- **Sane Python-side state:** center + an approximate Mercator zoom (`log2(360/span)`) are also set, so the view traitlets are reasonable before/without a rendered frontend; the JS fit supersedes them.
- **`compute_bounds` ported from deckgl_dash `bounds.py`** and exported publicly: recursively collects `[lon, lat]` pairs from point lists, `path`/`polygon`/`position` dicts, GeoJSON (FeatureCollection/Feature/geometry), and source/target positions (snake_case variants added for this library's conventions). New `position=["lon", "lat"]` convenience routes tabular data (DataFrame/DuckDB/list-of-dicts) through `materialize_rows`, matching layer accessor style: `m.fit_bounds(compute_bounds(df, position=["lon", "lat"]))`.

## Verification

12 new tests (`tests/test_bounds.py`): bounds from raw pairs, position/path dicts, GeoJSON FC with polygon, DataFrame via `position=`, custom accessor, no-coords error, plus `fit_bounds` request payload, `_seq` re-fire, and smaller-bounds→larger-zoom monotonicity. Full suite 261 passed; ruff/pyright clean; bundle rebuilds.

Note: the JS `fitBounds` wiring is exercised in-browser rather than by unit tests; flagged for the examples smoke pass at the end of the chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MB6bkjREt8tm7UkFjrogki
