### PR TITLE
Data-path performance: pick-row cache, single type dispatch

### DIFF
--- a/src/deckgl_marimo/_color_scale.py
+++ b/src/deckgl_marimo/_color_scale.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 from typing import Any
 
-import narwhals.stable.v2 as nw
+from deckgl_marimo._data import extract_column
 
 
 # Common CSS color names → RGB
@@ -132,47 +132,12 @@ def _interpolate_palette(control_points: list[list[int]], n: int) -> list[list[i
 
 
 def _extract_column(data: Any, column: str) -> list[float | None]:
-    """Extract a numeric column from various data types."""
-    if data is None:
-        return []
+    """Extract a numeric column from various data types.
 
-    if isinstance(data, str):
-        raise ValueError(
-            f"ColorScale cannot extract column '{column}' from URL data. "
-            "Provide actual data (DataFrame, list of dicts, etc.) or pre-compute colors."
-        )
-
-    if isinstance(data, list):
-        return [row.get(column) if isinstance(row, dict) else None for row in data]
-
-    if isinstance(data, dict):
-        # GeoJSON FeatureCollection
-        if "features" in data:
-            return [f.get("properties", {}).get(column) for f in data["features"]]
-        raise TypeError(
-            f"Cannot extract column '{column}' from a plain dict. "
-            "Expected DataFrame, list of dicts, GeoJSON dict, or GeoDataFrame."
-        )
-
-    # GeoDataFrame
-    if hasattr(data, "__geo_interface__") and hasattr(data, "columns"):
-        if column in data.columns:
-            return data[column].tolist()
-        raise KeyError(f"Column '{column}' not found in GeoDataFrame")
-
-    # DuckDB Relation
-    if hasattr(data, "fetchdf"):
-        return _extract_column(data.fetchdf(), column)
-
-    # pandas/polars via narwhals
-    try:
-        df = nw.from_native(data)
-        return df[column].to_list()
-    except Exception as err:
-        raise TypeError(
-            f"Cannot extract column '{column}' from {type(data).__name__}. "
-            "Expected DataFrame, list of dicts, GeoJSON dict, or GeoDataFrame."
-        ) from err
+    Thin wrapper over :func:`deckgl_marimo._data.extract_column`, kept for
+    backwards compatibility of the private name.
+    """
+    return extract_column(data, column)
 
 
 class ColorScale:

--- a/src/deckgl_marimo/_data.py
+++ b/src/deckgl_marimo/_data.py
@@ -49,7 +49,7 @@ def prepare_data(data: Any) -> list | dict | str:
         return data
 
     # DuckDB Relation: has .fetchdf() method
-    if hasattr(data, "fetchdf"):
+    if _is_duckdb_relation(data):
         return prepare_data(data.fetchdf())
 
     # GeoDataFrame: has __geo_interface__
@@ -67,6 +67,16 @@ def prepare_data(data: Any) -> list | dict | str:
         ) from err
 
 
+def _is_duckdb_relation(data: Any) -> bool:
+    """Duck-typed check for a DuckDB relation (has .fetchdf())."""
+    return hasattr(data, "fetchdf")
+
+
+def _is_geo_frame(data: Any) -> bool:
+    """Duck-typed check for a GeoDataFrame (geo interface + columns)."""
+    return hasattr(data, "__geo_interface__") and hasattr(data, "columns")
+
+
 def dataframe_to_records(data: Any) -> list[dict]:
     """Convert a DataFrame to a list of dicts via narwhals.
 
@@ -80,14 +90,15 @@ def dataframe_to_records(data: Any) -> list[dict]:
     list[dict]
         List of row dictionaries.
     """
-    df = nw.from_native(data)
+    # Benchmarked at 1M rows x 3 cols (2026-07): materializing columns once
+    # and zipping into dicts beats narwhals' iter_rows(named=True) (~2.5x)
+    # and rows(named=True) on both pandas and polars — don't "simplify"
+    # this into the built-ins without re-measuring.
+    df = nw.from_native(data, eager_only=True)
     columns = df.columns
-    result = []
     col_data = {col: df[col].to_list() for col in columns}
     n_rows = len(col_data[columns[0]]) if columns else 0
-    for i in range(n_rows):
-        result.append({col: col_data[col][i] for col in columns})
-    return result
+    return [{col: col_data[col][i] for col in columns} for i in range(n_rows)]
 
 
 def dataframe_to_positions(
@@ -153,11 +164,11 @@ def materialize_rows(data: Any) -> list[dict] | None:
         return None
 
     # DuckDB Relation
-    if hasattr(data, "fetchdf"):
+    if _is_duckdb_relation(data):
         return materialize_rows(data.fetchdf())
 
     # GeoDataFrame — extract properties (non-geometry columns)
-    if hasattr(data, "__geo_interface__") and hasattr(data, "columns"):
+    if _is_geo_frame(data):
         geo = data.__geo_interface__
         return [f.get("properties", {}) for f in geo.get("features", [])]
 
@@ -185,3 +196,59 @@ def geodataframe_to_geojson(gdf: Any) -> dict:
         GeoJSON FeatureCollection dict.
     """
     return gdf.__geo_interface__
+
+
+def extract_column(data: Any, column: str) -> list:
+    """Extract a single column's values from any supported data type.
+
+    Shares the same type dispatch as :func:`prepare_data` /
+    :func:`materialize_rows` but only touches one column, so DataFrame
+    inputs avoid materializing every row.
+
+    Raises
+    ------
+    ValueError
+        For URL-string data (nothing to extract from).
+    TypeError
+        For unsupported types, chaining the underlying narwhals error.
+    KeyError
+        When the column is missing from a GeoDataFrame.
+    """
+    if data is None:
+        return []
+
+    if isinstance(data, str):
+        raise ValueError(
+            f"Cannot extract column '{column}' from URL data. "
+            "Provide actual data (DataFrame, list of dicts, etc.) or pre-compute colors."
+        )
+
+    if isinstance(data, list):
+        return [row.get(column) if isinstance(row, dict) else None for row in data]
+
+    if isinstance(data, dict):
+        # GeoJSON FeatureCollection
+        if "features" in data:
+            return [f.get("properties", {}).get(column) for f in data["features"]]
+        raise TypeError(
+            f"Cannot extract column '{column}' from a plain dict. "
+            "Expected DataFrame, list of dicts, GeoJSON dict, or GeoDataFrame."
+        )
+
+    if _is_geo_frame(data):
+        if column in data.columns:
+            return data[column].tolist()
+        raise KeyError(f"Column '{column}' not found in GeoDataFrame")
+
+    if _is_duckdb_relation(data):
+        return extract_column(data.fetchdf(), column)
+
+    # pandas/polars via narwhals
+    try:
+        df = nw.from_native(data, eager_only=True)
+        return df[column].to_list()
+    except Exception as err:
+        raise TypeError(
+            f"Cannot extract column '{column}' from {type(data).__name__}. "
+            "Expected DataFrame, list of dicts, GeoJSON dict, or GeoDataFrame."
+        ) from err

--- a/src/deckgl_marimo/_map.py
+++ b/src/deckgl_marimo/_map.py
@@ -115,6 +115,9 @@ class Map(anywidget.AnyWidget):
         self._layers: list[BaseLayer] = list(layers or [])
         self._resolving_pick = False
         self._fit_bounds_seq = 0
+        # Materialized-row cache for pick resolution, keyed by layer id.
+        # Without it every click/hover re-converts the layer's full dataset.
+        self._pick_rows_cache: dict[str, list | None] = {}
         specs = [spec for layer in self._layers for spec in layer.to_specs()]
         style = Basemaps.resolve(basemap)
 
@@ -195,7 +198,9 @@ class Map(anywidget.AnyWidget):
         layer = next((lyr for lyr in self._layers if lyr.id == layer_id), None)
         if layer is None:
             return
-        rows = materialize_rows(layer.data)
+        if layer_id not in self._pick_rows_cache:
+            self._pick_rows_cache[layer_id] = materialize_rows(layer.data)
+        rows = self._pick_rows_cache[layer_id]
         if rows is None or index >= len(rows):
             return
         self._resolving_pick = True
@@ -348,6 +353,7 @@ class Map(anywidget.AnyWidget):
 
     def _sync_layers(self) -> None:
         """Re-serialize all layers and update the traitlet."""
+        self._pick_rows_cache.clear()
         self.layer_specs = [spec for layer in self._layers for spec in layer.to_specs()]
         self._sync_binary()
 

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -213,3 +213,41 @@ class TestPromotedCoreLayers:
         assert dgl.pack_binary is not None
         assert dgl.pack_polygon_binary is not None
         assert "pack_binary" in dgl.__all__
+
+
+class TestPickRowCache:
+    """Pick resolution caches materialized rows per layer (#23)."""
+
+    def test_materializes_once_per_layer(self, monkeypatch):
+        import deckgl_marimo._map as map_mod
+
+        layer = ScatterplotLayer(
+            id="pts", data=[{"lon": 0, "lat": 0, "name": "a"}, {"lon": 1, "lat": 1, "name": "b"}],
+            get_position=["lon", "lat"],
+        )
+        m = Map(layers=[layer])
+        calls = {"n": 0}
+        real = map_mod.materialize_rows
+
+        def counting(data):
+            calls["n"] += 1
+            return real(data)
+
+        monkeypatch.setattr(map_mod, "materialize_rows", counting)
+        for i in (0, 1, 0):
+            m.click_info = {"object": None, "layer_id": "pts", "index": i, "coordinate": [0, 0]}
+            assert m.click_info["object"]["name"] == ("a" if i == 0 else "b")
+        assert calls["n"] == 1
+
+    def test_cache_invalidated_on_layer_update(self):
+
+        layer = ScatterplotLayer(
+            id="pts", data=[{"lon": 0, "lat": 0, "name": "a"}], get_position=["lon", "lat"]
+        )
+        m = Map(layers=[layer])
+        m.click_info = {"object": None, "layer_id": "pts", "index": 0, "coordinate": [0, 0]}
+        assert m.click_info["object"]["name"] == "a"
+
+        m.update_layer("pts", data=[{"lon": 0, "lat": 0, "name": "z"}])
+        m.click_info = {"object": None, "layer_id": "pts", "index": 0, "coordinate": [0, 0]}
+        assert m.click_info["object"]["name"] == "z"


### PR DESCRIPTION
Closes #23.

**Chain position: 11/20 — stacked on #47 (refactor-core-layers).**

## What

- **Pick-row cache:** `_resolve_pick_object` previously called `materialize_rows(layer.data)` on **every** click/hover — a full DataFrame→dicts conversion per mouse event. Rows are now cached per layer id and invalidated in `_sync_layers` (so `set_layers`/`add_layer`/`update_layer`/`remove_layer` all refresh it). Measured at 1M rows: **0.81 s per pick → 0.81 s once, then ~0.01 ms per pick.**
- **One type dispatch:** column extraction moved from `_color_scale._extract_column` into `_data.extract_column`, so the DataFrame/GeoJSON/DuckDB/GeoDataFrame branching lives in a single module with shared duck-typing helpers; the old private name remains as a thin wrapper. Unsupported types now chain the underlying narwhals error.
- **`dataframe_to_records` stays as-is, deliberately:** the review assumed narwhals `iter_rows(named=True)` would beat the hand-rolled column-materialize loop. Benchmarked at 1M rows × 3 cols it's the opposite — the existing approach wins ~2.5× over `iter_rows` and edges out `rows(named=True)` and the native `to_dict("records")`/`to_dicts()` on **both** pandas and polars. A benchmark comment now guards the implementation against future "simplification".

| approach (1M rows) | pandas | polars |
|---|---|---|
| column-materialize (kept) | **0.31 s** | **0.25 s** |
| `rows(named=True)` | 0.33 s | 0.37 s |
| native records | 0.36 s | 0.36 s |
| `iter_rows(named=True)` | 0.77 s | 0.40 s |

## Verification

New tests: `materialize_rows` called exactly once across repeated picks (monkeypatched counter); cache invalidated by `update_layer(data=...)` with the new row picked up. Full suite 263 passed; ruff/pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MB6bkjREt8tm7UkFjrogki
