### PR TITLE
Gate the perf tracker behind an opt-in show_perf_metrics flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,16 +238,21 @@ Binary data is supported on: `ScatterplotLayer`, `PolygonLayer`, `PathLayer`, `A
 
 ### Performance metrics
 
-The `Map` widget includes a built-in FPS counter that reports metrics back to Python:
+The `Map` widget includes an opt-in FPS counter that reports metrics back
+to Python. It is off by default (the tracker pushes updates every 500 ms,
+which is wasted traffic for an idle map):
 
 ```python
-map_widget = dgl.Map(basemap="dark-matter", center=(0, 0), zoom=1)
+map_widget = dgl.Map(basemap="dark-matter", center=(0, 0), zoom=1, show_perf_metrics=True)
 widget = mo.ui.anywidget(map_widget)
 
-# Read performance metrics (updated every 500ms)
+# Read performance metrics (updated every 500ms while enabled)
 perf = widget.value.get("perf_metrics", {})
 fps = perf.get("fps")           # frames per second
 frame_time = perf.get("frameTimeAvg")  # ms per frame
+
+# Toggle at runtime
+map_widget.show_perf_metrics = False
 ```
 
 ### Authenticated remote data

--- a/js/src/__tests__/perf-tracker.test.js
+++ b/js/src/__tests__/perf-tracker.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPerfTracker } from "../perf-tracker.js";
+
+function stubRaf() {
+  let nextId = 1;
+  const scheduled = new Map();
+  vi.stubGlobal("requestAnimationFrame", (cb) => {
+    const id = nextId++;
+    scheduled.set(id, cb);
+    return id;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id) => scheduled.delete(id));
+  return scheduled;
+}
+
+describe("createPerfTracker", () => {
+  it("start is idempotent — never doubles the rAF loop", () => {
+    const scheduled = stubRaf();
+    const model = { set: vi.fn(), save_changes: vi.fn() };
+    const perf = createPerfTracker(model);
+    perf.start();
+    perf.start();
+    expect(scheduled.size).toBe(1);
+    perf.stop();
+    vi.unstubAllGlobals();
+  });
+
+  it("stop cancels the pending frame and allows a clean restart", () => {
+    const scheduled = stubRaf();
+    const model = { set: vi.fn(), save_changes: vi.fn() };
+    const perf = createPerfTracker(model);
+    perf.start();
+    perf.stop();
+    expect(scheduled.size).toBe(0);
+    perf.start();
+    expect(scheduled.size).toBe(1);
+    perf.stop();
+    vi.unstubAllGlobals();
+  });
+
+  it("pushes no metrics while stopped", () => {
+    const scheduled = stubRaf();
+    const model = { set: vi.fn(), save_changes: vi.fn() };
+    const perf = createPerfTracker(model);
+    perf.start();
+    perf.stop();
+    expect(model.set).not.toHaveBeenCalled();
+    expect(scheduled.size).toBe(0);
+    vi.unstubAllGlobals();
+  });
+});

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -59,9 +59,17 @@ async function render({ model, el }) {
   container.classList.add("deckgl-marimo-container");
   el.appendChild(container);
 
-  // --- Performance tracker ---
+  // --- Performance tracker (opt-in: show_perf_metrics) ---
   const perf = createPerfTracker(model);
-  perf.start();
+  const syncPerfTracker = () => {
+    if (model.get("show_perf_metrics")) {
+      perf.start();
+    } else {
+      perf.stop();
+    }
+  };
+  model.on("change:show_perf_metrics", syncPerfTracker);
+  syncPerfTracker();
 
   // --- MapLibre Map ---
   const map = new maplibregl.Map({

--- a/js/src/perf-tracker.js
+++ b/js/src/perf-tracker.js
@@ -55,8 +55,18 @@ export function createPerfTracker(model) {
   }
 
   return {
-    start() { animId = requestAnimationFrame(tick); },
-    stop() { if (animId) cancelAnimationFrame(animId); },
+    start() {
+      if (animId !== null) return; // idempotent — never double the rAF loop
+      lastTime = performance.now();
+      frameTimes.length = 0;
+      animId = requestAnimationFrame(tick);
+    },
+    stop() {
+      if (animId !== null) {
+        cancelAnimationFrame(animId);
+        animId = null;
+      }
+    },
     setDeck(d) { deckRef = d; },
   };
 }

--- a/src/deckgl_marimo/_map.py
+++ b/src/deckgl_marimo/_map.py
@@ -41,6 +41,11 @@ class Map(anywidget.AnyWidget):
         CSS height of the map container.
     width
         CSS width of the map container.
+    show_perf_metrics
+        Enable the FPS/frame-time tracker, which pushes ``perf_metrics``
+        updates every 500 ms while the widget is displayed. Off by
+        default to avoid constant traitlet traffic; can be toggled at
+        runtime (``m.show_perf_metrics = True``).
 
     Examples
     --------
@@ -61,7 +66,7 @@ class Map(anywidget.AnyWidget):
     # because Map has a single user-facing class; no MRO walking needed.
     _VALID_KWARGS: ClassVar[frozenset[str]] = frozenset({
         "layers", "basemap", "center", "zoom", "pitch", "bearing",
-        "height", "width",
+        "height", "width", "show_perf_metrics",
     })
 
     # Layer specifications (list of dicts from BaseLayer.to_spec())
@@ -85,6 +90,11 @@ class Map(anywidget.AnyWidget):
     binary_data = traitlets.Bytes(b"").tag(sync=True)
     binary_metadata = traitlets.Dict({}).tag(sync=True)
 
+    # Opt-in FPS/frame-time tracking. Off by default: the tracker runs a
+    # requestAnimationFrame loop that pushes perf_metrics over the wire
+    # every 500 ms — constant traitlet churn an idle map shouldn't pay.
+    show_perf_metrics = traitlets.Bool(False).tag(sync=True)
+
     # One-shot fit-bounds request applied by the JS side via map.fitBounds.
     # Carries a sequence number so repeated calls with identical bounds
     # still fire a change event.
@@ -107,6 +117,7 @@ class Map(anywidget.AnyWidget):
         bearing: float = 0.0,
         height: str = "600px",
         width: str = "100%",
+        show_perf_metrics: bool = False,
         _unsafe_props: bool = False,
         **kwargs: Any,
     ) -> None:
@@ -134,6 +145,7 @@ class Map(anywidget.AnyWidget):
             "bearing": bearing,
             "height": height,
             "width": width,
+            "show_perf_metrics": show_perf_metrics,
             **kwargs,
         }
 

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -251,3 +251,16 @@ class TestPickRowCache:
         m.update_layer("pts", data=[{"lon": 0, "lat": 0, "name": "z"}])
         m.click_info = {"object": None, "layer_id": "pts", "index": 0, "coordinate": [0, 0]}
         assert m.click_info["object"]["name"] == "z"
+
+
+class TestPerfMetricsOptIn:
+    """show_perf_metrics is off by default and toggleable (#24)."""
+
+    def test_default_off(self):
+        assert Map().show_perf_metrics is False
+
+    def test_constructor_and_runtime_toggle(self):
+        m = Map(show_perf_metrics=True)
+        assert m.show_perf_metrics is True
+        m.show_perf_metrics = False
+        assert m.show_perf_metrics is False


### PR DESCRIPTION
Closes #24.

**Chain position: 12/20 — stacked on #48 (perf/data-dispatch).**

## What

The FPS tracker ran an unconditional `requestAnimationFrame` loop pushing `perf_metrics` over the wire every 500 ms for every widget, forever — even idle maps generated constant Python-side traitlet churn (deckgl_dash gated its analogous profiling behind `DEBUG_PERF` in its review cycle).

- New synced traitlet + constructor kwarg `Map(show_perf_metrics=False)`; the JS side starts the tracker only when enabled and reacts to runtime toggles (`m.show_perf_metrics = True`).
- `perf-tracker.js` `start()` is now idempotent (a second `start()` can't double the rAF loop) and resets its frame samples; `stop()` cancels cleanly and permits restart.
- README performance-metrics section documents the opt-in and runtime toggle.

Mild behavior change: `perf_metrics` no longer populates unless enabled — previously-silent consumers must pass `show_perf_metrics=True`.

## Verification

Python: default-off + toggle tests (265 total). JS: 3 new vitest cases with stubbed rAF (idempotent start, stop-cancels-pending-frame + clean restart, no metric pushes while stopped) — 28 total. ruff/pyright clean; bundle rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MB6bkjREt8tm7UkFjrogki
