### PR TITLE
Add Makefile, CONTRIBUTING.md, CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Self-building wheels: the JS bundle is compiled at package-build time by a
+  hatchling hook (`hatch_build.py`); the bundle is no longer committed to git (#6)
+- `scripts/check_versions.py` / `scripts/release.py` — single-source version
+  across pyproject, js/package.json(+lock), and uv.lock, gated in CI and at
+  publish time (#7, #11)
+- ruff + pyright configured and enforced in CI; pytest-cov coverage (#8, #9)
+- vitest suite for the JS modules (zoom gating, binary reconstruction,
+  accessor resolution, perf tracker) (#10)
+- `Map.set_layers(layers)` — replace layers and re-pack binary buffers in one
+  call; the recommended reactive-update API (#30)
+- Real `Map.fit_bounds(bounds, padding=)` via JS `map.fitBounds`, plus public
+  `compute_bounds()` ported from deckgl_dash (#21)
+- Public `pack_binary` / `pack_polygon_binary` exports (#29)
+- `Map(show_perf_metrics=True)` opt-in for the FPS tracker (#24)
+- Smoke tests for all geo/mesh layer wrappers (#27)
+- `Makefile`, `CONTRIBUTING.md`, this changelog (#13)
+
+### Changed
+- **Breaking:** zoom-gated visibility props renamed `min_zoom`/`max_zoom` →
+  `visible_min_zoom`/`visible_max_zoom`; `TileLayer(min_zoom=, max_zoom=)`
+  now reach deck.gl as real tile-fetch bounds (#22)
+- **Breaking:** pandas removed from runtime dependencies (never imported);
+  marimo is now an optional extra (`deckgl-marimo[marimo]`) used only by
+  `as_widget()`; Python floor raised to 3.11; anywidget>=0.10,
+  traitlets>=5.14, narwhals>=2 (via `narwhals.stable.v2`) (#16)
+- `LineLayer`, `PointCloudLayer`, `SolidPolygonLayer` promoted to fully
+  tested core layers (no more experimental warning); layer taxonomy is now
+  15 tested + 17 experimental everywhere (#28)
+- deck.gl pinned `~9.3.6`, maplibre-gl `~5.24.0`, esbuild `^0.28.1` (#14, #15)
+- `layers/_core.py` refactored around a declarative `BINARY_ATTRIBUTES`
+  table + shared packer/stripper; tuple→list prop normalization moved into
+  `BaseLayer`; ~450 duplicated lines removed (#18)
+- Pick-event row lookup is cached per layer (a click on a 1M-row layer no
+  longer re-materializes the dataset every event) (#23)
+
+### Removed
+- **Breaking:** legacy `DeckGLHexagonWidget` (+ `widget.js`/`widget.css`) —
+  use `HexagonLayer` + `Map` (#26)
+- **Breaking:** unused `ViewState`, empty `controls/` package,
+  `_utils.to_snake_case` (#25)
+
+### Fixed
+- `PolygonLayer.to_binary()` dead code path that packed every vertex twice
+  on the ColorScale/callable path (#19)
+- `Map.update_layer()` prop routing: no longer probes the layer with
+  `hasattr` (which could silently no-op and instantiate a hidden Map);
+  unknown props raise the "did you mean" error (#20)
+- `Map.fit_bounds()` previously only centered — it now fits (#21)
+
+## [0.6.1] - 2026-06
+
+Historical release — see git history. Binary picking fixes; `as_widget()`
+added on `Map` and `BaseLayer`.
+
+## [0.6.0] - 2026-06
+
+Historical release — see git history. Binary data transport
+(`use_binary=True`, `pack_binary`), performance metrics, zoom-gated
+visibility, ColorScale, composite layers (Displacement, Ellipse).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing to deckgl-marimo
+
+## Prerequisites
+
+- Python 3.11+ and [uv](https://docs.astral.sh/uv/)
+- Node.js 20+ (see `.nvmrc`) and npm — required to build the JS bundle
+
+## Getting started
+
+```bash
+git clone https://github.com/kihaji/deckgl-marimo
+cd deckgl-marimo
+
+# JS bundle (the widget frontend) — build it once
+cd js && npm ci && npm run build && cd ..
+
+# Python environment (editable install; skips the JS build when the
+# bundle already exists)
+uv sync --extra dev
+```
+
+## Dev loop
+
+The widget is a single anywidget: Python (`src/deckgl_marimo/`) serializes
+layer specs and binary buffers; JS (`js/src/`) renders them with deck.gl on
+a MapLibre basemap.
+
+**Python changes** — the editable install picks them up immediately; run a
+marimo notebook from `examples/` to try them:
+
+```bash
+uv run marimo edit examples/01_scatterplot.py
+```
+
+**JS changes** — rebuild the bundle on save in a second terminal:
+
+```bash
+make watch        # = cd js && npm run watch
+```
+
+then hard-refresh the notebook page. The bundle
+(`src/deckgl_marimo/static/deckgl-marimo.bundle.js|css`) is a build
+product and is **not** committed to git; wheels build it automatically at
+package-build time via `hatch_build.py` (set
+`DECKGL_MARIMO_SKIP_JS_BUILD=1` to skip when the bundle is prebuilt).
+
+## Tests and quality gates
+
+```bash
+make test         # pytest (tests/)
+make test-js      # vitest (js/src/__tests__/)
+make quality      # ruff + pyright
+make check-versions
+```
+
+CI runs all of the above plus `uv lock --check` on Python 3.11–3.14, and
+builds a wheel through the self-building hook. Everything must be green.
+
+## Conventions
+
+- Python is snake_case; props convert to deck.gl camelCase at spec time
+  (`to_camel_case`). Accessor props are named `get_*`.
+- Public modules re-export through `src/deckgl_marimo/__init__.py`;
+  implementation modules are underscore-prefixed.
+- numpy-style docstrings.
+- New layer wrappers: declare `LAYER_TYPE`, keyword-only `__init__`
+  params (they double as the valid-prop list for typo validation), and a
+  `BINARY_ATTRIBUTES` table if the layer supports binary transport (see
+  `layers/_binary_attrs.py`).
+- Add tests beside the code you change; marimo notebooks in `examples/`
+  are runnable documentation — keep them working.
+
+## Releasing (maintainers)
+
+```bash
+uv run python scripts/release.py 0.7.0   # bump everywhere + verify + commit + tag
+git push && git push --tags
+```
+
+Then publish a GitHub Release from the tag — the `publish.yml` workflow
+verifies the tag matches the package version, builds via the hatch hook,
+and publishes to PyPI with OIDC trusted publishing. Update `CHANGELOG.md`
+as part of the release commit.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,100 @@
+# Makefile for deckgl-marimo
+#
+# Usage:
+#   make            - Build the JS bundle into src/deckgl_marimo/static/
+#   make watch      - Rebuild the bundle on JS source changes (dev loop)
+#   make clean      - Remove build artifacts
+#   make test       - Run the Python test suite
+#   make test-js    - Run the vitest JS suite
+#   make quality    - ruff (lint) + pyright (types)
+#   make check-versions [VERSION=x.y.z] - Verify all version sources agree
+#   make release VERSION=x.y.z - Verify clean tree + versions and tag
+#   make docs-serve - Serve docs locally at http://127.0.0.1:8000
+#   make docs-build - Build docs with strict mode
+#
+
+.PHONY: all build watch clean test test-js quality check-git check-version check-versions release docs-serve docs-build
+
+all: build
+
+# Build the production (minified) JS bundle
+build:
+	@echo "Building JS bundle..."
+	cd js && npm run build
+	@echo "Build complete: src/deckgl_marimo/static/deckgl-marimo.bundle.js"
+
+# Rebuild on change — pair with `uv sync` (editable install) for the dev loop
+watch:
+	cd js && npm run watch
+
+clean:
+	@echo "Cleaning build artifacts..."
+	rm -f src/deckgl_marimo/static/deckgl-marimo.bundle.js
+	rm -f src/deckgl_marimo/static/deckgl-marimo.bundle.css
+	rm -rf dist/
+	@echo "Clean complete"
+
+# Python test suite
+test:
+	uv run pytest
+
+# JS unit tests
+test-js:
+	cd js && npm test
+
+# Run code quality checks: ruff (lint) + pyright (types)
+quality:
+	@echo "Running ruff linter..."
+	uv run ruff check .
+	@echo "Running pyright type checker..."
+	uv run npx pyright
+	@echo ""
+	@echo "Quality check complete."
+
+# Check if git working directory is clean
+check-git:
+	@if [ -n "$$(git status --porcelain)" ]; then \
+		echo "Error: Working directory has uncommitted changes:"; \
+		git status --short; \
+		echo ""; \
+		echo "Please commit or stash changes before releasing."; \
+		exit 1; \
+	fi
+	@echo "Git working directory is clean"
+
+# Check that VERSION is provided
+check-version:
+	@if [ -z "$(VERSION)" ]; then \
+		echo "Error: VERSION is required"; \
+		echo "Usage: make release VERSION=x.y.z"; \
+		exit 1; \
+	fi
+	@echo "Release version: $(VERSION)"
+
+# Check that all version sources agree (and match VERSION when provided)
+check-versions:
+	uv run python scripts/check_versions.py $(VERSION)
+
+# Release target - verify clean tree + version consistency and tag
+# Use scripts/release.py to bump + verify + commit first, or bump by hand.
+release: check-version check-git check-versions
+	@echo ""
+	@echo "Creating git tag v$(VERSION)..."
+	git tag -a "v$(VERSION)" -m "Release v$(VERSION)"
+	@echo ""
+	@echo "=========================================="
+	@echo "Release v$(VERSION) prepared successfully!"
+	@echo "=========================================="
+	@echo ""
+	@echo "To publish:"
+	@echo "  git push && git push --tags"
+	@echo "  then create a GitHub Release from the tag (publishing triggers on Release published)"
+	@echo ""
+
+# Serve documentation locally
+docs-serve:
+	uv run --extra docs mkdocs serve
+
+# Build documentation with strict mode (catches broken links/warnings)
+docs-build:
+	uv run --extra docs mkdocs build --strict


### PR DESCRIPTION
Closes #13.

**Chain position: 15/20 — stacked on #51 (test/geo-mesh-smoke).**

## What

- **Makefile** — `build` / `watch` / `clean` / `test` / `test-js` / `quality` (ruff + pyright) / `check-versions` / `release VERSION=x.y.z` (clean-tree + version-agreement + annotated tag) / `docs-serve` / `docs-build`. Same shape as deckgl_dash's, adapted to the `js/` subdirectory and this repo's Release-triggered publish flow.
- **CONTRIBUTING.md** — the previously-undocumented dev loop: prerequisites, `npm ci && npm run build` + `uv sync --extra dev`, `make watch` for JS iteration, how the untracked bundle + hatch hook works, quality gates, layer-wrapper conventions (`LAYER_TYPE`, keyword-only params as the typo-validation source, `BINARY_ATTRIBUTES`), and the maintainer release process.
- **CHANGELOG.md** — Keep-a-Changelog format. The Unreleased section captures this entire review wave with issue references; 0.6.x entries backfilled from git history. (Avoided deckgl_dash's stale artifacts: no `poetry` references, no tracked `dist/`.)

## Verification

`make quality`, `make test` (294), `make check-versions` all green through the new targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MB6bkjREt8tm7UkFjrogki
