### PR TITLE
Add maplibre module: typed basemap composition (WMS/XYZ/vector/GeoJSON)

### DIFF
--- a/docs/api/maplibre.md
+++ b/docs/api/maplibre.md
@@ -1,0 +1,41 @@
+# MapLibre Composition
+
+::: deckgl_marimo.maplibre.MapLibreConfig
+
+::: deckgl_marimo.maplibre.empty_style
+
+## Sources
+
+::: deckgl_marimo.maplibre.RasterSource
+
+::: deckgl_marimo.maplibre.VectorSource
+
+::: deckgl_marimo.maplibre.GeoJSONSource
+
+## Style layers
+
+::: deckgl_marimo.maplibre.BaseMapLibreLayer
+
+::: deckgl_marimo.maplibre.FillLayer
+    options:
+      members: false
+
+::: deckgl_marimo.maplibre.LineLayer
+    options:
+      members: false
+
+::: deckgl_marimo.maplibre.RasterLayer
+    options:
+      members: false
+
+::: deckgl_marimo.maplibre.CircleLayer
+    options:
+      members: false
+
+::: deckgl_marimo.maplibre.SymbolLayer
+    options:
+      members: false
+
+::: deckgl_marimo.maplibre.FillExtrusionLayer
+    options:
+      members: false

--- a/docs/guides/basemaps.md
+++ b/docs/guides/basemaps.md
@@ -44,8 +44,35 @@ deck_map.basemap_style = dgl.Basemaps.resolve("voyager")
 ## Custom tile servers and WMS
 
 Any URL returning a [MapLibre style document](https://maplibre.org/maplibre-style-spec/)
-works, including styles that reference your own raster/WMS tile sources —
-this is the primary reason deckgl-marimo uses MapLibre for base layers.
-Typed style composition from Python (adding WMS sources to a named style
-without hand-writing style JSON) is tracked in
-[issue #35](https://github.com/kihaji/deckgl-marimo/issues/35).
+works. But you don't need to hand-write style JSON: the
+`deckgl_marimo.maplibre` module composes a base style with extra sources
+and MapLibre layers from Python — the primary reason this library uses
+MapLibre for base layers:
+
+```python
+from deckgl_marimo.maplibre import MapLibreConfig, RasterSource, RasterLayer
+
+config = MapLibreConfig(
+    style="positron",                       # alias, URL, or inline spec
+    sources={
+        "topo": RasterSource.from_wms(
+            base_url="https://ows.terrestris.de/osm/service",
+            layers="TOPO-WMS",
+        ),
+    },
+    map_layers=[RasterLayer(id="topo", source="topo", raster_opacity=0.7)],
+)
+m = dgl.Map(basemap=config, layers=[...])
+```
+
+`RasterSource.from_wms` builds the GetMap tile-URL template (WMS 1.1.1 or
+1.3.x) for you. Also available: plain XYZ `RasterSource`, `VectorSource`
+(PBF/MVT + `promote_id`), `GeoJSONSource` (with clustering), and typed
+style layers (`FillLayer`, `LineLayer`, `RasterLayer`, `CircleLayer`,
+`SymbolLayer`, `FillExtrusionLayer`). Use
+`deckgl_marimo.maplibre.empty_style()` for WMS-only maps with no base
+style. Swap the whole composition at runtime by assigning
+`m.maplibre_config = config.to_dict()`.
+
+See `examples/16_maplibre_wms.py` for a runnable demo and the
+[MapLibre API reference](../api/maplibre.md).

--- a/examples/16_maplibre_wms.py
+++ b/examples/16_maplibre_wms.py
@@ -1,0 +1,114 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+#     "deckgl-marimo",
+# ]
+#
+# [tool.uv.sources]
+# deckgl-marimo = { path = ".." }
+# ///
+"""Composed basemap: WMS raster source + deck.gl overlay.
+
+Demonstrates the maplibre module — the reason this library uses MapLibre
+for base layers: add a WMS topo layer onto a named basemap style from
+Python, no hand-written style JSON, with a deck.gl scatterplot on top.
+"""
+
+import marimo
+
+__generated_with = "0.22.0"
+app = marimo.App(width="full")
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    import deckgl_marimo as dgl
+    from deckgl_marimo.maplibre import MapLibreConfig, RasterLayer, RasterSource
+
+    return MapLibreConfig, RasterLayer, RasterSource, dgl, mo
+
+
+@app.cell
+def _(mo):
+    opacity = mo.ui.slider(0.0, 1.0, step=0.1, value=0.7, show_value=True, label="WMS opacity")
+    opacity
+    return (opacity,)
+
+
+@app.cell
+def _(MapLibreConfig, RasterLayer, RasterSource, dgl):
+    # Stable Map cell (no slider deps). The config composes:
+    #   positron base style  +  terrestris demo WMS  (+ deck.gl on top)
+    deck_map = dgl.Map(
+        basemap=MapLibreConfig(
+            style="positron",
+            sources={
+                "topo-wms": RasterSource.from_wms(
+                    base_url="https://ows.terrestris.de/osm/service",
+                    layers="TOPO-WMS",
+                    attribution="© terrestris",
+                ),
+            },
+            map_layers=[
+                RasterLayer(id="topo", source="topo-wms", raster_opacity=0.7),
+            ],
+        ),
+        center=(7.1, 50.7),
+        zoom=7,
+    )
+    widget = deck_map.as_widget()
+    return deck_map, widget
+
+
+@app.cell
+def _(widget):
+    widget
+    return
+
+
+@app.cell
+def _(deck_map, dgl):
+    # deck.gl overlay on top of the composed basemap
+    cities = [
+        {"name": "Köln", "lon": 6.96, "lat": 50.94, "pop": 1084},
+        {"name": "Bonn", "lon": 7.10, "lat": 50.73, "pop": 331},
+        {"name": "Koblenz", "lon": 7.59, "lat": 50.36, "pop": 114},
+        {"name": "Frankfurt", "lon": 8.68, "lat": 50.11, "pop": 753},
+    ]
+    deck_map.set_layers([
+        dgl.ScatterplotLayer(
+            data=cities,
+            get_position=["lon", "lat"],
+            get_radius="pop",
+            radius_scale=20,
+            radius_min_pixels=4,
+            get_fill_color=[220, 60, 60, 220],
+        )
+    ])
+    return
+
+
+@app.cell
+def _(MapLibreConfig, RasterLayer, RasterSource, deck_map, opacity):
+    # Reactive: swap the config when the slider moves (the map itself is stable)
+    deck_map.maplibre_config = MapLibreConfig(
+        style="positron",
+        sources={
+            "topo-wms": RasterSource.from_wms(
+                base_url="https://ows.terrestris.de/osm/service",
+                layers="TOPO-WMS",
+                attribution="© terrestris",
+            ),
+        },
+        map_layers=[
+            RasterLayer(id="topo", source="topo-wms", raster_opacity=opacity.value),
+        ],
+    ).to_dict()
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,7 @@ uv run marimo edit examples/01_scatterplot.py
 | 13 | [13_polygon_color_scale.py](13_polygon_color_scale.py) | ColorScale on polygons |
 | 14 | [14_zoom_visibility.py](14_zoom_visibility.py) | `visible_min_zoom`/`visible_max_zoom` gating |
 | 15 | [15_polygon_zoom_visibility.py](15_polygon_zoom_visibility.py) | Zoom gating with polygon detail levels |
+| 16 | [16_maplibre_wms.py](16_maplibre_wms.py) | Composed basemap: WMS source via `maplibre.MapLibreConfig` |
 
 ## Feature demos
 

--- a/js/src/__tests__/maplibre-config.test.js
+++ b/js/src/__tests__/maplibre-config.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { applyConfigExtras, resolveStyle } from "../maplibre-config.js";
+
+const FALLBACK = { version: 8, sources: {}, layers: [] };
+
+function fakeMap() {
+  const sources = new Map();
+  const layers = new Map();
+  return {
+    sources,
+    layers,
+    getSource: (id) => sources.get(id),
+    addSource: (id, spec) => sources.set(id, spec),
+    getLayer: (id) => layers.get(id),
+    addLayer: (spec) => layers.set(spec.id, spec),
+  };
+}
+
+describe("resolveStyle", () => {
+  it("prefers a config's style over basemap_style", () => {
+    expect(resolveStyle({ style: "https://cfg" }, "https://plain", FALLBACK)).toBe("https://cfg");
+  });
+
+  it("falls back to basemap_style, then the fallback", () => {
+    expect(resolveStyle({}, "https://plain", FALLBACK)).toBe("https://plain");
+    expect(resolveStyle(null, "", FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("passes inline style objects through", () => {
+    const inline = { version: 8, sources: {}, layers: [] };
+    expect(resolveStyle({ style: inline }, "", FALLBACK)).toBe(inline);
+  });
+});
+
+describe("applyConfigExtras", () => {
+  const config = {
+    style: "https://s",
+    sources: { wms: { type: "raster", tiles: ["https://t/{z}/{x}/{y}"] } },
+    mapLayers: [{ id: "wms-layer", type: "raster", source: "wms" }],
+  };
+
+  it("adds sources and layers", () => {
+    const map = fakeMap();
+    applyConfigExtras(map, config);
+    expect(map.sources.get("wms").type).toBe("raster");
+    expect(map.layers.get("wms-layer").source).toBe("wms");
+  });
+
+  it("is idempotent across repeated style loads", () => {
+    const map = fakeMap();
+    applyConfigExtras(map, config);
+    applyConfigExtras(map, config); // second style.load
+    expect(map.sources.size).toBe(1);
+    expect(map.layers.size).toBe(1);
+  });
+
+  it("tolerates empty/missing config", () => {
+    const map = fakeMap();
+    applyConfigExtras(map, null);
+    applyConfigExtras(map, {});
+    expect(map.sources.size).toBe(0);
+  });
+});

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -13,6 +13,7 @@ import { normalizeBinaryBuffer } from "./binary-buffer.js";
 import { applyZoomVisibility, zoomVisibilityKey } from "./zoom-visibility.js";
 import { createPerfTracker } from "./perf-tracker.js";
 import { attachPickHandlers } from "./pick-events.js";
+import { applyConfigExtras, resolveStyle } from "./maplibre-config.js";
 
 /**
  * Inject MapLibre CSS into the document if not already present.
@@ -72,21 +73,34 @@ async function render({ model, el }) {
   syncPerfTracker();
 
   // --- MapLibre Map ---
+  const FALLBACK_STYLE = {
+    version: 8,
+    sources: {},
+    layers: [{ id: "background", type: "background", paint: { "background-color": "#111" } }],
+  };
+  const mlConfig = model.get("maplibre_config");
   const map = new maplibregl.Map({
     container,
-    style: model.get("basemap_style") || {
-      version: 8,
-      sources: {},
-      layers: [{ id: "background", type: "background", paint: { "background-color": "#111" } }],
-    },
+    style: resolveStyle(mlConfig, model.get("basemap_style"), FALLBACK_STYLE),
     center: [model.get("longitude") || 0, model.get("latitude") || 0],
     zoom: model.get("zoom") || 1,
     pitch: model.get("pitch") || 0,
     bearing: model.get("bearing") || 0,
     canvasContextAttributes: { antialias: true },
+    ...((mlConfig && mlConfig.mapOptions) || {}),
   });
 
   map.addControl(new maplibregl.NavigationControl(), "top-right");
+
+  // Composed-basemap extras (WMS/XYZ/vector sources + style layers).
+  // setStyle wipes user sources, so reapply after every style load.
+  map.on("style.load", () => {
+    applyConfigExtras(map, model.get("maplibre_config"));
+  });
+  model.on("change:maplibre_config", () => {
+    const cfg = model.get("maplibre_config");
+    map.setStyle(resolveStyle(cfg, model.get("basemap_style"), FALLBACK_STYLE));
+  });
 
   // --- deck.gl Overlay ---
   const overlay = new MapboxOverlay({

--- a/js/src/maplibre-config.js
+++ b/js/src/maplibre-config.js
@@ -1,0 +1,35 @@
+/**
+ * Composed basemap configuration: a base style plus extra MapLibre
+ * sources and style layers, delivered from Python as the
+ * `maplibre_config` traitlet ({style, sources, mapLayers, mapOptions}).
+ *
+ * Deliberately free of maplibre-gl imports so it stays unit-testable.
+ */
+
+/**
+ * Pick the style to load: a non-empty config's style wins over the plain
+ * basemap_style string; otherwise fall back.
+ */
+export function resolveStyle(config, basemapStyle, fallback) {
+  if (config && config.style) return config.style;
+  return basemapStyle || fallback;
+}
+
+/**
+ * Apply a config's extra sources and layers onto the map. Idempotent —
+ * safe to call after every style load (setStyle wipes user sources, so
+ * this must re-run on the `style.load` event).
+ */
+export function applyConfigExtras(map, config) {
+  if (!config) return;
+  for (const [id, source] of Object.entries(config.sources || {})) {
+    if (!map.getSource(id)) {
+      map.addSource(id, source);
+    }
+  }
+  for (const layer of config.mapLayers || []) {
+    if (!map.getLayer(layer.id)) {
+      map.addLayer(layer);
+    }
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - ColorScale: api/color-scale.md
       - Binary Packing: api/binary.md
       - Bounds: api/bounds.md
+      - MapLibre Composition: api/maplibre.md
   - Internals:
       - Binary Transfer Research: internals/binary-transfer-research.md
   - Troubleshooting: troubleshooting.md

--- a/src/deckgl_marimo/_map.py
+++ b/src/deckgl_marimo/_map.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pathlib
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import anywidget
 import traitlets
@@ -11,6 +11,9 @@ import traitlets
 from deckgl_marimo._base import BaseLayer, _raise_for_unknown_props
 from deckgl_marimo._basemaps import Basemaps
 from deckgl_marimo._data import materialize_rows
+
+if TYPE_CHECKING:
+    from deckgl_marimo.maplibre import MapLibreConfig
 
 _STATIC = pathlib.Path(__file__).parent / "static"
 
@@ -27,8 +30,12 @@ class Map(anywidget.AnyWidget):
     layers
         List of :class:`BaseLayer` instances to render.
     basemap
-        Basemap style name or URL. Use :class:`Basemaps` aliases like
-        ``"dark-matter"`` or a full MapLibre style URL.
+        Basemap style. Accepts a :class:`Basemaps` alias like
+        ``"dark-matter"``, a full MapLibre style URL, an inline MapLibre
+        style spec dict, or a
+        :class:`~deckgl_marimo.maplibre.MapLibreConfig` composing a base
+        style with extra sources (WMS/XYZ/vector/GeoJSON) and MapLibre
+        layers.
     center
         Initial map center as ``(longitude, latitude)``.
     zoom
@@ -82,6 +89,12 @@ class Map(anywidget.AnyWidget):
     # Basemap
     basemap_style = traitlets.Unicode("").tag(sync=True)
 
+    # Composed basemap configuration (maplibre.MapLibreConfig.to_dict()):
+    # {style, sources, mapLayers, mapOptions}. When non-empty, its style
+    # wins over basemap_style and the extra sources/layers are applied
+    # after every style load.
+    maplibre_config = traitlets.Dict({}).tag(sync=True)
+
     # Layout
     height = traitlets.Unicode("600px").tag(sync=True)
     width = traitlets.Unicode("100%").tag(sync=True)
@@ -110,7 +123,7 @@ class Map(anywidget.AnyWidget):
         self,
         layers: list[BaseLayer] | None = None,
         *,
-        basemap: str = "dark-matter",
+        basemap: str | dict[str, Any] | MapLibreConfig = "dark-matter",
         center: tuple[float, float] | None = None,
         zoom: float = 1.0,
         pitch: float = 0.0,
@@ -130,7 +143,19 @@ class Map(anywidget.AnyWidget):
         # Without it every click/hover re-converts the layer's full dataset.
         self._pick_rows_cache: dict[str, list | None] = {}
         specs = [spec for layer in self._layers for spec in layer.to_specs()]
-        style = Basemaps.resolve(basemap)
+
+        # basemap accepts: alias/URL string, a maplibre.MapLibreConfig, a
+        # config dict ({"style": ...}), or an inline MapLibre style spec.
+        style = ""
+        ml_config: dict[str, Any] = {}
+        if isinstance(basemap, str):
+            style = Basemaps.resolve(basemap)
+        elif isinstance(basemap, dict):
+            # A config dict ({"style": ...}) or an inline MapLibre style spec
+            ml_config = basemap if "style" in basemap else {"style": basemap}
+        else:
+            # MapLibreConfig (anything exposing to_dict)
+            ml_config = basemap.to_dict()
 
         # Pre-pack binary data for layers that use binary mode
         bin_meta, bin_data = self._pack_binary(self._layers)
@@ -138,6 +163,7 @@ class Map(anywidget.AnyWidget):
         init_kwargs: dict[str, Any] = {
             "layer_specs": specs,
             "basemap_style": style,
+            "maplibre_config": ml_config,
             "binary_data": bin_data,
             "binary_metadata": bin_meta,
             "zoom": zoom,

--- a/src/deckgl_marimo/maplibre/__init__.py
+++ b/src/deckgl_marimo/maplibre/__init__.py
@@ -1,0 +1,35 @@
+"""Typed MapLibre basemap composition for deckgl-marimo.
+
+Compose a base style plus extra sources (WMS/XYZ raster, vector tiles,
+GeoJSON) and MapLibre style layers from Python — no hand-written style
+JSON. Pass a :class:`MapLibreConfig` as ``Map(basemap=...)``.
+"""
+
+from deckgl_marimo.maplibre._config import MapLibreConfig, empty_style
+from deckgl_marimo.maplibre._layers import (
+    BaseMapLibreLayer,
+    CircleLayer,
+    FillExtrusionLayer,
+    FillLayer,
+    LineLayer,
+    RasterLayer,
+    SymbolLayer,
+)
+from deckgl_marimo.maplibre._sources import GeoJSONSource, RasterSource, VectorSource
+
+__all__ = [
+    "MapLibreConfig",
+    "empty_style",
+    # Sources
+    "RasterSource",
+    "VectorSource",
+    "GeoJSONSource",
+    # Layers
+    "BaseMapLibreLayer",
+    "FillLayer",
+    "LineLayer",
+    "RasterLayer",
+    "CircleLayer",
+    "SymbolLayer",
+    "FillExtrusionLayer",
+]

--- a/src/deckgl_marimo/maplibre/_config.py
+++ b/src/deckgl_marimo/maplibre/_config.py
@@ -1,0 +1,107 @@
+"""MapLibre configuration for composed basemaps.
+
+Ported from deckgl_dash's ``maplibre/config.py``, adapted to reuse this
+library's :class:`~deckgl_marimo.Basemaps` catalog for style aliases.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from deckgl_marimo._basemaps import Basemaps
+
+
+def empty_style() -> dict[str, Any]:
+    """An empty MapLibre style spec — for WMS-only / layers-only maps."""
+    return {"version": 8, "sources": {}, "layers": []}
+
+
+class MapLibreConfig:
+    """Composed basemap configuration: a base style plus extra sources/layers.
+
+    Pass to ``Map(basemap=config)``. The frontend loads the base style and
+    then applies the additional sources and MapLibre layers on top —
+    without hand-writing a full style JSON document.
+
+    Examples
+    --------
+    WMS raster over a named basemap::
+
+        from deckgl_marimo.maplibre import MapLibreConfig, RasterSource, RasterLayer
+
+        config = MapLibreConfig(
+            style="positron",
+            sources={"wms": RasterSource.from_wms(
+                "https://ows.terrestris.de/osm/service", layers="TOPO-WMS",
+            )},
+            map_layers=[RasterLayer(id="wms-topo", source="wms", raster_opacity=0.7)],
+        )
+        m = dgl.Map(basemap=config, layers=[...])
+
+    Custom vector tiles::
+
+        config = MapLibreConfig(
+            style="dark-matter",
+            sources={"custom": VectorSource(tiles=["https://example.com/{z}/{x}/{y}.pbf"])},
+            map_layers=[FillLayer(id="custom-fill", source="custom", source_layer="buildings")],
+        )
+
+    Parameters
+    ----------
+    style
+        Basemap alias (``"positron"``), MapLibre style URL, or inline style
+        spec dict. Use :func:`empty_style` for WMS-only maps.
+    sources
+        Extra sources keyed by source id — values may be Source objects
+        (:class:`RasterSource`, :class:`VectorSource`,
+        :class:`GeoJSONSource`) or raw spec dicts.
+    map_layers
+        Extra MapLibre style layers — Layer objects
+        (:class:`RasterLayer`, :class:`FillLayer`, ...) or raw spec dicts.
+        Applied in order after the base style loads.
+    map_options
+        Additional options merged into the MapLibre ``Map`` constructor.
+    """
+
+    def __init__(
+        self,
+        style: str | dict[str, Any] = "dark-matter",
+        sources: dict[str, Any] | None = None,
+        map_layers: list[Any] | None = None,
+        map_options: dict[str, Any] | None = None,
+    ) -> None:
+        self.style = style
+        self.sources = sources or {}
+        self.map_layers = map_layers or []
+        self.map_options = map_options or {}
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to the dict shape the widget's ``maplibre_config`` traitlet carries."""
+        style = self.style
+        if isinstance(style, str):
+            style = Basemaps.resolve(style)
+
+        sources = {
+            source_id: spec.to_dict() if hasattr(spec, "to_dict") else spec
+            for source_id, spec in self.sources.items()
+        }
+        layers = [
+            spec.to_dict() if hasattr(spec, "to_dict") else spec
+            for spec in self.map_layers
+        ]
+
+        result: dict[str, Any] = {"style": style}
+        if sources:
+            result["sources"] = sources
+        if layers:
+            result["mapLayers"] = layers
+        if self.map_options:
+            result["mapOptions"] = self.map_options
+        return result
+
+    def __repr__(self) -> str:
+        style_repr = self.style if isinstance(self.style, str) else "<inline style>"
+        return (
+            f"MapLibreConfig(style={style_repr!r}, sources={len(self.sources)}, "
+            f"map_layers={len(self.map_layers)})"
+        )

--- a/src/deckgl_marimo/maplibre/_layers.py
+++ b/src/deckgl_marimo/maplibre/_layers.py
@@ -1,0 +1,449 @@
+"""MapLibre style-layer wrappers.
+
+These are MapLibre GL JS style layers, NOT deck.gl layers — use them for
+styling raster/vector/GeoJSON sources rendered by the basemap engine
+underneath the deck.gl overlay.
+
+Ported from deckgl_dash's ``maplibre/layers.py``. Convenience kwargs are
+snake_case and map onto MapLibre's kebab-case paint/layout properties;
+anything not covered can be passed via the ``paint=`` / ``layout=`` dicts.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# MapLibre expression, e.g. ["get", "height"]
+Expression = list[Any]
+# Static value or expression
+PropertyValue = Any
+
+
+def _set_kebab(target: dict[str, Any], values: dict[str, Any]) -> None:
+    """Copy non-None convenience kwargs into a paint/layout dict, kebab-cased."""
+    for key, value in values.items():
+        if value is not None:
+            target[key.replace("_", "-")] = value
+
+
+class BaseMapLibreLayer:
+    """Base class for MapLibre style layers.
+
+    Parameters
+    ----------
+    id
+        Unique layer ID within the style.
+    source
+        Source ID this layer draws from.
+    source_layer
+        Source layer name (required for vector tile sources).
+    min_zoom, max_zoom
+        Zoom range for layer visibility (MapLibre ``minzoom``/``maxzoom``).
+    filter
+        MapLibre filter expression.
+    layout
+        Raw layout properties (kebab-case keys) merged after convenience kwargs.
+    paint
+        Raw paint properties (kebab-case keys) merged after convenience kwargs.
+    metadata
+        Arbitrary metadata dict.
+    """
+
+    _layer_type: str = ""
+
+    def __init__(
+        self,
+        id: str,
+        source: str,
+        source_layer: str | None = None,
+        min_zoom: float | None = None,
+        max_zoom: float | None = None,
+        filter: Expression | None = None,
+        layout: dict[str, PropertyValue] | None = None,
+        paint: dict[str, PropertyValue] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        self.id = id
+        self.source = source
+        self.source_layer = source_layer
+        self.min_zoom = min_zoom
+        self.max_zoom = max_zoom
+        self.filter = filter
+        self.layout = dict(layout or {})
+        self.paint = dict(paint or {})
+        self.metadata = metadata
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a MapLibre layer spec dict."""
+        result: dict[str, Any] = {"id": self.id, "type": self._layer_type, "source": self.source}
+        if self.source_layer:
+            result["source-layer"] = self.source_layer
+        if self.min_zoom is not None:
+            result["minzoom"] = self.min_zoom
+        if self.max_zoom is not None:
+            result["maxzoom"] = self.max_zoom
+        if self.filter:
+            result["filter"] = self.filter
+        if self.layout:
+            result["layout"] = self.layout
+        if self.paint:
+            result["paint"] = self.paint
+        if self.metadata:
+            result["metadata"] = self.metadata
+        return result
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(id={self.id!r}, source={self.source!r})"
+
+
+class FillLayer(BaseMapLibreLayer):
+    """MapLibre fill layer — filled polygons.
+
+    Example
+    -------
+    ::
+
+        FillLayer(
+            id="buildings", source="vector-tiles", source_layer="building",
+            fill_color="#ff0000", fill_opacity=0.5,
+        )
+    """
+
+    _layer_type = "fill"
+
+    def __init__(
+        self,
+        id: str,
+        source: str,
+        source_layer: str | None = None,
+        fill_color: PropertyValue | None = None,
+        fill_opacity: PropertyValue | None = None,
+        fill_outline_color: PropertyValue | None = None,
+        fill_pattern: PropertyValue | None = None,
+        fill_antialias: bool | None = None,
+        fill_translate: list[float] | None = None,
+        fill_translate_anchor: str | None = None,
+        visibility: str | None = None,
+        fill_sort_key: PropertyValue | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(id, source, source_layer, **kwargs)
+        _set_kebab(self.paint, {
+            "fill_color": fill_color,
+            "fill_opacity": fill_opacity,
+            "fill_outline_color": fill_outline_color,
+            "fill_pattern": fill_pattern,
+            "fill_antialias": fill_antialias,
+            "fill_translate": fill_translate,
+            "fill_translate_anchor": fill_translate_anchor,
+        })
+        _set_kebab(self.layout, {
+            "visibility": visibility,
+            "fill_sort_key": fill_sort_key,
+        })
+
+
+class LineLayer(BaseMapLibreLayer):
+    """MapLibre line layer — lines and polygon outlines.
+
+    Example
+    -------
+    ::
+
+        LineLayer(
+            id="roads", source="vector-tiles", source_layer="road",
+            line_color="#000000", line_width=2,
+        )
+    """
+
+    _layer_type = "line"
+
+    def __init__(
+        self,
+        id: str,
+        source: str,
+        source_layer: str | None = None,
+        line_color: PropertyValue | None = None,
+        line_width: PropertyValue | None = None,
+        line_opacity: PropertyValue | None = None,
+        line_blur: PropertyValue | None = None,
+        line_dasharray: list[float] | None = None,
+        line_gap_width: PropertyValue | None = None,
+        line_offset: PropertyValue | None = None,
+        line_pattern: PropertyValue | None = None,
+        line_translate: list[float] | None = None,
+        line_translate_anchor: str | None = None,
+        line_gradient: Expression | None = None,
+        visibility: str | None = None,
+        line_cap: str | None = None,
+        line_join: str | None = None,
+        line_miter_limit: float | None = None,
+        line_round_limit: float | None = None,
+        line_sort_key: PropertyValue | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(id, source, source_layer, **kwargs)
+        _set_kebab(self.paint, {
+            "line_color": line_color,
+            "line_width": line_width,
+            "line_opacity": line_opacity,
+            "line_blur": line_blur,
+            "line_dasharray": line_dasharray,
+            "line_gap_width": line_gap_width,
+            "line_offset": line_offset,
+            "line_pattern": line_pattern,
+            "line_translate": line_translate,
+            "line_translate_anchor": line_translate_anchor,
+            "line_gradient": line_gradient,
+        })
+        _set_kebab(self.layout, {
+            "visibility": visibility,
+            "line_cap": line_cap,
+            "line_join": line_join,
+            "line_miter_limit": line_miter_limit,
+            "line_round_limit": line_round_limit,
+            "line_sort_key": line_sort_key,
+        })
+
+
+class RasterLayer(BaseMapLibreLayer):
+    """MapLibre raster layer — renders a raster (XYZ/WMS) source.
+
+    Example
+    -------
+    ::
+
+        RasterLayer(id="wms-topo", source="wms", raster_opacity=0.8)
+    """
+
+    _layer_type = "raster"
+
+    def __init__(
+        self,
+        id: str,
+        source: str,
+        raster_opacity: float | None = None,
+        raster_hue_rotate: float | None = None,
+        raster_brightness_min: float | None = None,
+        raster_brightness_max: float | None = None,
+        raster_saturation: float | None = None,
+        raster_contrast: float | None = None,
+        raster_resampling: str | None = None,
+        raster_fade_duration: float | None = None,
+        visibility: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        # Raster layers don't use source_layer
+        super().__init__(id, source, source_layer=None, **kwargs)
+        _set_kebab(self.paint, {
+            "raster_opacity": raster_opacity,
+            "raster_hue_rotate": raster_hue_rotate,
+            "raster_brightness_min": raster_brightness_min,
+            "raster_brightness_max": raster_brightness_max,
+            "raster_saturation": raster_saturation,
+            "raster_contrast": raster_contrast,
+            "raster_resampling": raster_resampling,
+            "raster_fade_duration": raster_fade_duration,
+        })
+        _set_kebab(self.layout, {"visibility": visibility})
+
+
+class CircleLayer(BaseMapLibreLayer):
+    """MapLibre circle layer — points as circles.
+
+    Example
+    -------
+    ::
+
+        CircleLayer(
+            id="points", source="geojson-points",
+            circle_radius=6, circle_color="#007cbf",
+        )
+    """
+
+    _layer_type = "circle"
+
+    def __init__(
+        self,
+        id: str,
+        source: str,
+        source_layer: str | None = None,
+        circle_radius: PropertyValue | None = None,
+        circle_color: PropertyValue | None = None,
+        circle_blur: PropertyValue | None = None,
+        circle_opacity: PropertyValue | None = None,
+        circle_stroke_width: PropertyValue | None = None,
+        circle_stroke_color: PropertyValue | None = None,
+        circle_stroke_opacity: PropertyValue | None = None,
+        circle_translate: list[float] | None = None,
+        circle_translate_anchor: str | None = None,
+        circle_pitch_scale: str | None = None,
+        circle_pitch_alignment: str | None = None,
+        visibility: str | None = None,
+        circle_sort_key: PropertyValue | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(id, source, source_layer, **kwargs)
+        _set_kebab(self.paint, {
+            "circle_radius": circle_radius,
+            "circle_color": circle_color,
+            "circle_blur": circle_blur,
+            "circle_opacity": circle_opacity,
+            "circle_stroke_width": circle_stroke_width,
+            "circle_stroke_color": circle_stroke_color,
+            "circle_stroke_opacity": circle_stroke_opacity,
+            "circle_translate": circle_translate,
+            "circle_translate_anchor": circle_translate_anchor,
+            "circle_pitch_scale": circle_pitch_scale,
+            "circle_pitch_alignment": circle_pitch_alignment,
+        })
+        _set_kebab(self.layout, {
+            "visibility": visibility,
+            "circle_sort_key": circle_sort_key,
+        })
+
+
+class SymbolLayer(BaseMapLibreLayer):
+    """MapLibre symbol layer — text labels and icons.
+
+    Example
+    -------
+    ::
+
+        SymbolLayer(
+            id="labels", source="places",
+            text_field=["get", "name"], text_size=12, text_color="#000000",
+        )
+    """
+
+    _layer_type = "symbol"
+
+    def __init__(
+        self,
+        id: str,
+        source: str,
+        source_layer: str | None = None,
+        # layout (symbols style mostly via layout)
+        text_field: PropertyValue | None = None,
+        text_size: PropertyValue | None = None,
+        text_font: list[str] | None = None,
+        text_anchor: str | None = None,
+        text_offset: list[float] | None = None,
+        text_max_width: PropertyValue | None = None,
+        text_justify: str | None = None,
+        text_rotation_alignment: str | None = None,
+        text_pitch_alignment: str | None = None,
+        text_transform: str | None = None,
+        text_letter_spacing: PropertyValue | None = None,
+        text_line_height: PropertyValue | None = None,
+        icon_image: PropertyValue | None = None,
+        icon_size: PropertyValue | None = None,
+        icon_anchor: str | None = None,
+        icon_offset: list[float] | None = None,
+        icon_rotation_alignment: str | None = None,
+        icon_pitch_alignment: str | None = None,
+        symbol_placement: str | None = None,
+        symbol_spacing: float | None = None,
+        symbol_sort_key: PropertyValue | None = None,
+        visibility: str | None = None,
+        # paint
+        text_color: PropertyValue | None = None,
+        text_opacity: PropertyValue | None = None,
+        text_halo_color: PropertyValue | None = None,
+        text_halo_width: PropertyValue | None = None,
+        text_halo_blur: PropertyValue | None = None,
+        icon_color: PropertyValue | None = None,
+        icon_opacity: PropertyValue | None = None,
+        icon_halo_color: PropertyValue | None = None,
+        icon_halo_width: PropertyValue | None = None,
+        icon_halo_blur: PropertyValue | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(id, source, source_layer, **kwargs)
+        _set_kebab(self.layout, {
+            "text_field": text_field,
+            "text_size": text_size,
+            "text_font": text_font,
+            "text_anchor": text_anchor,
+            "text_offset": text_offset,
+            "text_max_width": text_max_width,
+            "text_justify": text_justify,
+            "text_rotation_alignment": text_rotation_alignment,
+            "text_pitch_alignment": text_pitch_alignment,
+            "text_transform": text_transform,
+            "text_letter_spacing": text_letter_spacing,
+            "text_line_height": text_line_height,
+            "icon_image": icon_image,
+            "icon_size": icon_size,
+            "icon_anchor": icon_anchor,
+            "icon_offset": icon_offset,
+            "icon_rotation_alignment": icon_rotation_alignment,
+            "icon_pitch_alignment": icon_pitch_alignment,
+            "symbol_placement": symbol_placement,
+            "symbol_spacing": symbol_spacing,
+            "symbol_sort_key": symbol_sort_key,
+            "visibility": visibility,
+        })
+        _set_kebab(self.paint, {
+            "text_color": text_color,
+            "text_opacity": text_opacity,
+            "text_halo_color": text_halo_color,
+            "text_halo_width": text_halo_width,
+            "text_halo_blur": text_halo_blur,
+            "icon_color": icon_color,
+            "icon_opacity": icon_opacity,
+            "icon_halo_color": icon_halo_color,
+            "icon_halo_width": icon_halo_width,
+            "icon_halo_blur": icon_halo_blur,
+        })
+
+
+class FillExtrusionLayer(BaseMapLibreLayer):
+    """MapLibre fill-extrusion layer — 3D extruded polygons.
+
+    Example
+    -------
+    ::
+
+        FillExtrusionLayer(
+            id="buildings-3d", source="vector-tiles", source_layer="building",
+            fill_extrusion_color="#aaa",
+            fill_extrusion_height=["get", "height"],
+            fill_extrusion_opacity=0.6,
+        )
+    """
+
+    _layer_type = "fill-extrusion"
+
+    def __init__(
+        self,
+        id: str,
+        source: str,
+        source_layer: str | None = None,
+        fill_extrusion_color: PropertyValue | None = None,
+        fill_extrusion_opacity: float | None = None,
+        fill_extrusion_height: PropertyValue | None = None,
+        fill_extrusion_base: PropertyValue | None = None,
+        fill_extrusion_pattern: PropertyValue | None = None,
+        fill_extrusion_translate: list[float] | None = None,
+        fill_extrusion_translate_anchor: str | None = None,
+        fill_extrusion_vertical_gradient: bool | None = None,
+        visibility: str | None = None,
+        fill_extrusion_edge_radius: float | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(id, source, source_layer, **kwargs)
+        _set_kebab(self.paint, {
+            "fill_extrusion_color": fill_extrusion_color,
+            "fill_extrusion_opacity": fill_extrusion_opacity,
+            "fill_extrusion_height": fill_extrusion_height,
+            "fill_extrusion_base": fill_extrusion_base,
+            "fill_extrusion_pattern": fill_extrusion_pattern,
+            "fill_extrusion_translate": fill_extrusion_translate,
+            "fill_extrusion_translate_anchor": fill_extrusion_translate_anchor,
+            "fill_extrusion_vertical_gradient": fill_extrusion_vertical_gradient,
+        })
+        _set_kebab(self.layout, {
+            "visibility": visibility,
+            "fill_extrusion_edge_radius": fill_extrusion_edge_radius,
+        })

--- a/src/deckgl_marimo/maplibre/_sources.py
+++ b/src/deckgl_marimo/maplibre/_sources.py
@@ -1,0 +1,333 @@
+"""MapLibre source wrappers.
+
+Ported from deckgl_dash's ``maplibre/sources.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+
+class RasterSource:
+    """MapLibre raster tile source.
+
+    Used for XYZ tile servers, WMS, WMTS, or any raster tile endpoint —
+    the primary building block for composing WMS base layers, which is
+    this library's headline MapLibre use case.
+
+    Examples
+    --------
+    XYZ tiles::
+
+        RasterSource(tiles=["https://tile.openstreetmap.org/{z}/{x}/{y}.png"])
+
+    WMS::
+
+        RasterSource.from_wms(
+            base_url="https://ows.terrestris.de/osm/service",
+            layers="TOPO-WMS",
+        )
+
+    Parameters
+    ----------
+    tiles
+        Tile URL templates with ``{z}``, ``{x}``, ``{y}`` placeholders.
+    tile_size
+        Tile size in pixels.
+    min_zoom, max_zoom
+        Zoom range at which tiles are requested.
+    bounds
+        Bounding box ``[west, south, east, north]`` in WGS84.
+    attribution
+        Attribution string for the source.
+    scheme
+        Tile scheme: ``"xyz"`` (default) or ``"tms"``.
+    """
+
+    def __init__(
+        self,
+        tiles: list[str] | None = None,
+        tile_size: int = 256,
+        min_zoom: int = 0,
+        max_zoom: int = 22,
+        bounds: list[float] | None = None,
+        attribution: str | None = None,
+        scheme: str = "xyz",
+    ) -> None:
+        self.tiles = tiles or []
+        self.tile_size = tile_size
+        self.min_zoom = min_zoom
+        self.max_zoom = max_zoom
+        self.bounds = bounds
+        self.attribution = attribution
+        self.scheme = scheme
+
+    @classmethod
+    def from_wms(
+        cls,
+        base_url: str,
+        layers: str,
+        tile_size: int = 256,
+        format: str = "image/png",
+        transparent: bool = True,
+        version: str = "1.1.1",
+        crs: str = "EPSG:3857",
+        styles: str = "",
+        extra_params: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> RasterSource:
+        """Create a raster source from a WMS endpoint.
+
+        Builds a GetMap tile-URL template with MapLibre's
+        ``{bbox-epsg-3857}`` placeholder.
+
+        Parameters
+        ----------
+        base_url
+            WMS service base URL (query parameters are merged if present).
+        layers
+            WMS layer name(s); comma-separate multiple layers.
+        tile_size
+            Tile size in pixels (also sent as WIDTH/HEIGHT).
+        format
+            Image format, e.g. ``"image/png"``.
+        transparent
+            Request a transparent background.
+        version
+            WMS version; 1.3.x switches SRS -> CRS automatically.
+        crs
+            Coordinate reference system (Web Mercator by default).
+        styles
+            WMS STYLES parameter.
+        extra_params
+            Additional WMS query parameters.
+        **kwargs
+            Forwarded to :class:`RasterSource` (bounds, attribution, ...).
+        """
+        params = {
+            "SERVICE": "WMS",
+            "VERSION": version,
+            "REQUEST": "GetMap",
+            "LAYERS": layers,
+            "STYLES": styles,
+            "FORMAT": format,
+            "TRANSPARENT": "TRUE" if transparent else "FALSE",
+            "WIDTH": str(tile_size),
+            "HEIGHT": str(tile_size),
+        }
+        if version.startswith("1.3"):
+            params["CRS"] = crs
+        else:
+            params["SRS"] = crs
+        params["BBOX"] = "{bbox-epsg-3857}"
+
+        if extra_params:
+            params.update(extra_params)
+
+        parsed = urlparse(base_url)
+        for key, value in parse_qs(parsed.query).items():
+            if key.upper() not in params:
+                params[key.upper()] = value[0] if value else ""
+
+        query_string = urlencode(params, safe="{}-")
+        wms_url = urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", query_string, ""))
+        return cls(tiles=[wms_url], tile_size=tile_size, **kwargs)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a MapLibre source spec dict."""
+        result: dict[str, Any] = {"type": "raster", "tiles": self.tiles, "tileSize": self.tile_size}
+        if self.min_zoom != 0:
+            result["minzoom"] = self.min_zoom
+        if self.max_zoom != 22:
+            result["maxzoom"] = self.max_zoom
+        if self.bounds:
+            result["bounds"] = self.bounds
+        if self.attribution:
+            result["attribution"] = self.attribution
+        if self.scheme != "xyz":
+            result["scheme"] = self.scheme
+        return result
+
+    def __repr__(self) -> str:
+        return f"RasterSource(tiles={self.tiles}, tile_size={self.tile_size})"
+
+
+class VectorSource:
+    """MapLibre vector tile source for PBF/MVT tiles.
+
+    Examples
+    --------
+    ::
+
+        VectorSource(tiles=["https://example.com/{z}/{x}/{y}.pbf"])
+        VectorSource(url="https://example.com/tiles.json")   # TileJSON
+
+    Parameters
+    ----------
+    tiles
+        Tile URL templates (alternative to ``url``).
+    url
+        TileJSON URL (alternative to ``tiles``).
+    min_zoom, max_zoom
+        Zoom range at which tiles are requested.
+    bounds
+        Bounding box ``[west, south, east, north]`` in WGS84.
+    attribution
+        Attribution string.
+    scheme
+        ``"xyz"`` (default) or ``"tms"``.
+    promote_id
+        Property to use as feature ID — a string applied to all layers,
+        or a dict mapping source-layer names to properties.
+    """
+
+    def __init__(
+        self,
+        tiles: list[str] | None = None,
+        url: str | None = None,
+        min_zoom: int = 0,
+        max_zoom: int = 22,
+        bounds: list[float] | None = None,
+        attribution: str | None = None,
+        scheme: str = "xyz",
+        promote_id: str | dict[str, str] | None = None,
+    ) -> None:
+        self.tiles = tiles
+        self.url = url
+        self.min_zoom = min_zoom
+        self.max_zoom = max_zoom
+        self.bounds = bounds
+        self.attribution = attribution
+        self.scheme = scheme
+        self.promote_id = promote_id
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a MapLibre source spec dict."""
+        result: dict[str, Any] = {"type": "vector"}
+        if self.tiles:
+            result["tiles"] = self.tiles
+        if self.url:
+            result["url"] = self.url
+        if self.min_zoom != 0:
+            result["minzoom"] = self.min_zoom
+        if self.max_zoom != 22:
+            result["maxzoom"] = self.max_zoom
+        if self.bounds:
+            result["bounds"] = self.bounds
+        if self.attribution:
+            result["attribution"] = self.attribution
+        if self.scheme != "xyz":
+            result["scheme"] = self.scheme
+        if self.promote_id:
+            result["promoteId"] = self.promote_id
+        return result
+
+    def __repr__(self) -> str:
+        if self.url:
+            return f"VectorSource(url={self.url!r})"
+        return f"VectorSource(tiles={self.tiles})"
+
+
+class GeoJSONSource:
+    """MapLibre GeoJSON source for inline or remote GeoJSON data.
+
+    Examples
+    --------
+    ::
+
+        GeoJSONSource(data={"type": "FeatureCollection", "features": [...]})
+        GeoJSONSource(data="https://example.com/data.geojson")
+
+    Parameters
+    ----------
+    data
+        GeoJSON dict or URL string.
+    cluster
+        Enable point clustering.
+    cluster_radius
+        Cluster radius in pixels.
+    cluster_max_zoom
+        Max zoom to cluster points.
+    cluster_min_points
+        Minimum points to form a cluster.
+    cluster_properties
+        Custom aggregation expressions for clusters.
+    line_metrics
+        Calculate line distance metrics (needed for line-gradient).
+    tolerance
+        Douglas-Peucker simplification tolerance.
+    buffer
+        Tile buffer size.
+    max_zoom
+        Maximum zoom level to generate tiles for.
+    attribution
+        Attribution string.
+    promote_id
+        Property to use as feature ID.
+    generate_id
+        Auto-generate feature IDs.
+    """
+
+    def __init__(
+        self,
+        data: str | dict[str, Any],
+        cluster: bool = False,
+        cluster_radius: int = 50,
+        cluster_max_zoom: int | None = None,
+        cluster_min_points: int = 2,
+        cluster_properties: dict[str, Any] | None = None,
+        line_metrics: bool = False,
+        tolerance: float = 0.375,
+        buffer: int = 128,
+        max_zoom: int = 18,
+        attribution: str | None = None,
+        promote_id: str | None = None,
+        generate_id: bool = False,
+    ) -> None:
+        self.data = data
+        self.cluster = cluster
+        self.cluster_radius = cluster_radius
+        self.cluster_max_zoom = cluster_max_zoom
+        self.cluster_min_points = cluster_min_points
+        self.cluster_properties = cluster_properties
+        self.line_metrics = line_metrics
+        self.tolerance = tolerance
+        self.buffer = buffer
+        self.max_zoom = max_zoom
+        self.attribution = attribution
+        self.promote_id = promote_id
+        self.generate_id = generate_id
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a MapLibre source spec dict."""
+        result: dict[str, Any] = {"type": "geojson", "data": self.data}
+        if self.cluster:
+            result["cluster"] = True
+            result["clusterRadius"] = self.cluster_radius
+            if self.cluster_max_zoom is not None:
+                result["clusterMaxZoom"] = self.cluster_max_zoom
+            if self.cluster_min_points != 2:
+                result["clusterMinPoints"] = self.cluster_min_points
+            if self.cluster_properties:
+                result["clusterProperties"] = self.cluster_properties
+        if self.line_metrics:
+            result["lineMetrics"] = True
+        if self.tolerance != 0.375:
+            result["tolerance"] = self.tolerance
+        if self.buffer != 128:
+            result["buffer"] = self.buffer
+        if self.max_zoom != 18:
+            result["maxzoom"] = self.max_zoom
+        if self.attribution:
+            result["attribution"] = self.attribution
+        if self.promote_id:
+            result["promoteId"] = self.promote_id
+        if self.generate_id:
+            result["generateId"] = True
+        return result
+
+    def __repr__(self) -> str:
+        if isinstance(self.data, str):
+            return f"GeoJSONSource(data={self.data!r})"
+        return f"GeoJSONSource(data=<{len(self.data.get('features', []))} features>)"

--- a/tests/test_maplibre.py
+++ b/tests/test_maplibre.py
@@ -1,0 +1,184 @@
+"""Tests for the maplibre composition module (#35)."""
+
+import pytest
+
+from deckgl_marimo import Map
+from deckgl_marimo.maplibre import (
+    CircleLayer,
+    FillExtrusionLayer,
+    FillLayer,
+    GeoJSONSource,
+    LineLayer,
+    MapLibreConfig,
+    RasterLayer,
+    RasterSource,
+    SymbolLayer,
+    VectorSource,
+    empty_style,
+)
+
+
+class TestRasterSource:
+    def test_xyz_to_dict(self):
+        src = RasterSource(tiles=["https://tile.example/{z}/{x}/{y}.png"], attribution="© x")
+        assert src.to_dict() == {
+            "type": "raster",
+            "tiles": ["https://tile.example/{z}/{x}/{y}.png"],
+            "tileSize": 256,
+            "attribution": "© x",
+        }
+
+    def test_wms_url_template(self):
+        src = RasterSource.from_wms(
+            "https://ows.terrestris.de/osm/service", layers="TOPO-WMS"
+        )
+        url = src.to_dict()["tiles"][0]
+        assert url.startswith("https://ows.terrestris.de/osm/service?")
+        assert "SERVICE=WMS" in url
+        assert "REQUEST=GetMap" in url
+        assert "LAYERS=TOPO-WMS" in url
+        assert "SRS=EPSG%3A3857" in url          # 1.1.1 uses SRS
+        assert "BBOX={bbox-epsg-3857}" in url    # placeholder must stay literal
+        assert "WIDTH=256" in url
+
+    def test_wms_130_uses_crs(self):
+        src = RasterSource.from_wms("https://w.example/wms", layers="l", version="1.3.0")
+        url = src.to_dict()["tiles"][0]
+        assert "CRS=EPSG%3A3857" in url
+        assert "SRS=" not in url
+
+    def test_wms_merges_existing_query_params(self):
+        src = RasterSource.from_wms("https://w.example/wms?map=/maps/x.map", layers="l")
+        url = src.to_dict()["tiles"][0]
+        assert "MAP=%2Fmaps%2Fx.map" in url
+
+    def test_wms_extra_params_and_kwargs(self):
+        src = RasterSource.from_wms(
+            "https://w.example/wms", layers="l",
+            extra_params={"TILED": "TRUE"}, attribution="© wms", min_zoom=3,
+        )
+        d = src.to_dict()
+        assert "TILED=TRUE" in d["tiles"][0]
+        assert d["attribution"] == "© wms"
+        assert d["minzoom"] == 3
+
+
+class TestVectorAndGeoJSONSources:
+    def test_vector_source(self):
+        src = VectorSource(tiles=["https://t.example/{z}/{x}/{y}.pbf"], promote_id="fid")
+        d = src.to_dict()
+        assert d["type"] == "vector"
+        assert d["promoteId"] == "fid"
+
+    def test_vector_tilejson(self):
+        assert VectorSource(url="https://t.example/tiles.json").to_dict()["url"]
+
+    def test_geojson_source_with_clustering(self):
+        src = GeoJSONSource(data="https://d.example/x.geojson", cluster=True, cluster_radius=80)
+        d = src.to_dict()
+        assert d["type"] == "geojson"
+        assert d["cluster"] is True
+        assert d["clusterRadius"] == 80
+
+
+class TestMapLibreLayers:
+    def test_kebab_case_paint_and_layout(self):
+        layer = FillLayer(
+            id="f", source="s", source_layer="buildings",
+            fill_color="#f00", fill_opacity=0.5, visibility="visible",
+        )
+        d = layer.to_dict()
+        assert d["type"] == "fill"
+        assert d["source-layer"] == "buildings"
+        assert d["paint"] == {"fill-color": "#f00", "fill-opacity": 0.5}
+        assert d["layout"] == {"visibility": "visible"}
+
+    def test_raster_layer(self):
+        d = RasterLayer(id="r", source="wms", raster_opacity=0.7).to_dict()
+        assert d == {"id": "r", "type": "raster", "source": "wms", "paint": {"raster-opacity": 0.7}}
+
+    def test_zoom_and_filter(self):
+        d = LineLayer(
+            id="l", source="s", line_width=2,
+            min_zoom=5, max_zoom=15, filter=["==", "class", "primary"],
+        ).to_dict()
+        assert d["minzoom"] == 5
+        assert d["maxzoom"] == 15
+        assert d["filter"] == ["==", "class", "primary"]
+
+    def test_symbol_expression_values(self):
+        d = SymbolLayer(id="t", source="s", text_field=["get", "name"], text_color="#000").to_dict()
+        assert d["layout"]["text-field"] == ["get", "name"]
+        assert d["paint"]["text-color"] == "#000"
+
+    def test_circle_and_extrusion(self):
+        assert CircleLayer(id="c", source="s", circle_radius=6).to_dict()["paint"]["circle-radius"] == 6
+        d = FillExtrusionLayer(id="e", source="s", fill_extrusion_height=["get", "h"]).to_dict()
+        assert d["type"] == "fill-extrusion"
+        assert d["paint"]["fill-extrusion-height"] == ["get", "h"]
+
+    def test_raw_paint_dict_merges(self):
+        d = FillLayer(id="f", source="s", fill_color="#f00", paint={"fill-opacity": 0.1}).to_dict()
+        assert d["paint"] == {"fill-opacity": 0.1, "fill-color": "#f00"}
+
+
+class TestMapLibreConfig:
+    def test_resolves_style_alias(self):
+        cfg = MapLibreConfig(style="positron")
+        assert cfg.to_dict()["style"].startswith("https://basemaps.cartocdn.com")
+
+    def test_passes_url_and_inline_style(self):
+        assert MapLibreConfig(style="https://x.example/s.json").to_dict()["style"] == "https://x.example/s.json"
+        inline = empty_style()
+        assert MapLibreConfig(style=inline).to_dict()["style"] == inline
+
+    def test_serializes_objects_and_dicts(self):
+        cfg = MapLibreConfig(
+            style=empty_style(),
+            sources={
+                "wms": RasterSource(tiles=["https://t/{z}/{x}/{y}"]),
+                "raw": {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}},
+            },
+            map_layers=[RasterLayer(id="r", source="wms"), {"id": "raw-l", "type": "circle", "source": "raw"}],
+            map_options={"maxPitch": 70},
+        )
+        d = cfg.to_dict()
+        assert d["sources"]["wms"]["type"] == "raster"
+        assert d["sources"]["raw"]["type"] == "geojson"
+        assert [layer["id"] for layer in d["mapLayers"]] == ["r", "raw-l"]
+        assert d["mapOptions"] == {"maxPitch": 70}
+
+
+class TestMapIntegration:
+    def test_map_accepts_config(self):
+        cfg = MapLibreConfig(
+            style="dark-matter",
+            sources={"wms": RasterSource(tiles=["https://t/{z}/{x}/{y}"])},
+            map_layers=[RasterLayer(id="r", source="wms")],
+        )
+        m = Map(basemap=cfg)
+        assert m.maplibre_config["style"].startswith("https://basemaps.cartocdn.com")
+        assert "wms" in m.maplibre_config["sources"]
+        assert m.basemap_style == ""
+
+    def test_map_accepts_inline_style_dict(self):
+        m = Map(basemap=empty_style())
+        assert m.maplibre_config["style"]["version"] == 8
+
+    def test_map_accepts_config_dict(self):
+        m = Map(basemap={"style": "positron", "sources": {}})
+        assert m.maplibre_config["style"] == "positron"
+
+    def test_plain_string_still_works(self):
+        m = Map(basemap="dark-matter")
+        assert m.basemap_style.startswith("https://basemaps.cartocdn.com")
+        assert m.maplibre_config == {}
+
+    def test_runtime_config_swap(self):
+        m = Map(basemap="dark-matter")
+        m.maplibre_config = MapLibreConfig(style="positron").to_dict()
+        assert "positron" in m.maplibre_config["style"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #35.

**Chain position: 18/20 — stacked on #54 (chore/examples-reorg).**

## What

The project's stated rationale is MapLibre for WMS/tile-server base layers — yet only a style name/URL was accepted. This ports deckgl_dash's `maplibre/` module, adapted to this repo's conventions:

**Python (`deckgl_marimo.maplibre`)**
- `MapLibreConfig(style, sources, map_layers, map_options)` — style accepts a `Basemaps` alias, URL, or inline spec; `empty_style()` for WMS-only maps
- Sources: `RasterSource` (incl. `from_wms()` which builds the GetMap tile-URL template for WMS 1.1.1/1.3.x, preserving `{bbox-epsg-3857}` and merging pre-existing query params), `VectorSource` (PBF/MVT, `promote_id`), `GeoJSONSource` (clustering options)
- Style layers: `FillLayer`/`LineLayer`/`RasterLayer`/`CircleLayer`/`SymbolLayer`/`FillExtrusionLayer` — snake_case convenience kwargs map to kebab-case paint/layout, raw `paint=`/`layout=` dicts still accepted
- `Map(basemap=...)` accepts all forms; new synced `maplibre_config` traitlet is swappable at runtime (`m.maplibre_config = cfg.to_dict()`)

**JS**
- `maplibre-config.js`: `resolveStyle` (config style > basemap_style > fallback) + idempotent `applyConfigExtras`; extras reapply on every `style.load` since `setStyle` wipes user sources; `mapOptions` merge into the MapLibre constructor

**Docs & example**
- `examples/16_maplibre_wms.py` — the headline use case: terrestris WMS topo over positron, deck.gl scatter overlay, reactive opacity slider on the stable-map pattern
- Basemaps guide rewritten around composition; `api/maplibre.md` autodoc page

Deliberately excluded: `interleaved` overlay mode (deckgl_dash has it) — that's the subject of open issue #4 and needs its own investigation here.

## Verification

22 new Python tests (WMS URL construction incl. 1.3.0 CRS switch and query-param merge, source/layer spec shapes, kebab-case mapping, config serialization of objects+raw dicts, all four `Map(basemap=...)` input forms, runtime swap) — 316 total. 6 new vitest cases (style resolution precedence, idempotent extras across repeated style loads) — 34 total. ruff/pyright clean; bundle rebuilds; docs build strict.

Browser-level rendering of the WMS example is flagged for the end-of-chain smoke pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MB6bkjREt8tm7UkFjrogki
