### PR TITLE
Add drawing/editing via @deck.gl-community/editable-layers

### DIFF
--- a/docs/api/drawing.md
+++ b/docs/api/drawing.md
@@ -1,0 +1,5 @@
+# Drawing
+
+::: deckgl_marimo.DrawingConfig
+
+::: deckgl_marimo.DrawingStyle

--- a/docs/guides/drawing.md
+++ b/docs/guides/drawing.md
@@ -1,0 +1,69 @@
+# Drawing & Editing
+
+Draw and edit features directly on the map — polygons, lines, points,
+circles, rectangles — with the results arriving in Python as GeoJSON.
+Powered by `@deck.gl-community/editable-layers`.
+
+## Enable a drawing mode
+
+```python
+m = dgl.Map(
+    basemap="positron",
+    drawing_config=dgl.DrawingConfig(
+        mode="draw_polygon",
+        style=dgl.DrawingStyle(fill_color=[255, 140, 0, 100], line_width=2),
+    ),
+)
+widget = m.as_widget()
+```
+
+**Modes:** `draw_polygon`, `draw_line`, `draw_point`, `draw_circle`,
+`draw_rectangle`, `draw_square`, `modify` (drag vertices), `translate`
+(drag whole features), `delete` (click a feature to remove it), `view`
+(off).
+
+Switch modes reactively by assigning
+`m.drawing_config = dgl.DrawingConfig("modify").to_dict()` from any cell
+— the map stays stable.
+
+## Read the drawn features
+
+```python
+features = widget.value.get("drawing_features", {})   # GeoJSON FeatureCollection
+event = widget.value.get("drawing_event", {})         # {"type", "featureCount", "timestamp"}
+```
+
+The cell re-runs whenever a feature is added, moved, edited, or deleted.
+Feed the collection straight back into a `GeoJsonLayer`, run a spatial
+query with it, or persist it.
+
+## Seed or clear features from Python
+
+```python
+m.drawing_features = my_feature_collection     # seed
+m.drawing_features = dict(dgl.EMPTY_FEATURE_COLLECTION)  # clear
+```
+
+## Selection and deletion
+
+In `modify`/`translate` modes, clicking a feature selects it. To delete
+the selection programmatically:
+
+```python
+m.drawing_config = dgl.DrawingConfig("modify", delete_selected=True).to_dict()
+```
+
+The frontend deletes the selected feature(s), emits a `deleteFeature`
+event, and resets the flag. `delete` mode is the interactive
+alternative: every click deletes the clicked feature.
+
+## Interaction notes
+
+- Drag-drawn shapes (`draw_circle`, `draw_rectangle`, `draw_square`)
+  temporarily disable map panning; other modes keep it.
+- Double-click zoom is disabled while any drawing mode is active
+  (double-click finishes polygons/lines).
+- Measurement tooltips show while drawing lines/circles; disable with
+  `DrawingStyle(show_measurements=False)`.
+
+See `examples/18_drawing.py` for a runnable demo with a mode switcher.

--- a/examples/18_drawing.py
+++ b/examples/18_drawing.py
@@ -1,0 +1,103 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+#     "deckgl-marimo",
+# ]
+#
+# [tool.uv.sources]
+# deckgl-marimo = { path = ".." }
+# ///
+"""Interactive drawing/editing on the map.
+
+Draw polygons, lines, circles, and points; modify or translate them;
+click features to delete them in delete mode. Drawn features arrive in
+Python as GeoJSON via the reactive `drawing_features` value.
+"""
+
+import marimo
+
+__generated_with = "0.22.0"
+app = marimo.App(width="full")
+
+
+@app.cell
+def _():
+    import json
+
+    import marimo as mo
+
+    import deckgl_marimo as dgl
+
+    return dgl, json, mo
+
+
+@app.cell
+def _(mo):
+    mode = mo.ui.radio(
+        options=[
+            "view", "draw_polygon", "draw_line", "draw_point",
+            "draw_circle", "draw_rectangle", "modify", "translate", "delete",
+        ],
+        value="draw_polygon",
+        label="Mode",
+        inline=True,
+    )
+    mode
+    return (mode,)
+
+
+@app.cell
+def _(dgl):
+    # Stable Map cell — the drawing config is swapped reactively below.
+    deck_map = dgl.Map(basemap="positron", center=(-98.5, 39.8), zoom=4)
+    widget = deck_map.as_widget()
+    return deck_map, widget
+
+
+@app.cell
+def _(widget):
+    widget
+    return
+
+
+@app.cell
+def _(deck_map, dgl, mode):
+    # Reactive: switch drawing mode from the radio control
+    deck_map.drawing_config = dgl.DrawingConfig(
+        mode.value,
+        style=dgl.DrawingStyle(
+            fill_color=[255, 140, 0, 100],
+            line_color="#222222",
+            line_width=2,
+        ),
+    ).to_dict()
+    return
+
+
+@app.cell
+def _(json, mo, widget):
+    features = widget.value.get("drawing_features", {}) or {}
+    event = widget.value.get("drawing_event", {}) or {}
+    n = len(features.get("features", []))
+    mo.md(f"""
+**{n} feature(s) drawn** — last event: `{event.get("type", "—")}`
+
+```json
+{json.dumps(features, indent=2)[:2000]}
+```
+""")
+    return
+
+
+@app.cell
+def _(deck_map, dgl, mo):
+    clear = mo.ui.run_button(label="Clear all features")
+    if clear.value:
+        deck_map.drawing_features = dict(dgl.EMPTY_FEATURE_COLLECTION)
+    clear
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,6 +29,7 @@ uv run marimo edit examples/01_scatterplot.py
 | 15 | [15_polygon_zoom_visibility.py](15_polygon_zoom_visibility.py) | Zoom gating with polygon detail levels |
 | 16 | [16_maplibre_wms.py](16_maplibre_wms.py) | Composed basemap: WMS source via `maplibre.MapLibreConfig` |
 | 17 | [17_time_filter.py](17_time_filter.py) | GPU time filter: animated sliding window over 100k points |
+| 18 | [18_drawing.py](18_drawing.py) | Interactive drawing/editing with GeoJSON readback |
 
 ## Feature demos
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -8,6 +8,8 @@
       "name": "deckgl-marimo-js",
       "version": "0.6.1",
       "dependencies": {
+        "@deck.gl-community/editable-layers": "~9.3.7",
+        "@deck.gl-community/layers": "~9.3.7",
         "@deck.gl/aggregation-layers": "~9.3.6",
         "@deck.gl/core": "~9.3.6",
         "@deck.gl/extensions": "~9.3.6",
@@ -23,6 +25,173 @@
       },
       "engines": {
         "node": ">=20.9"
+      }
+    },
+    "node_modules/@deck.gl-community/editable-layers": {
+      "version": "9.3.7",
+      "resolved": "https://registry.npmjs.org/@deck.gl-community/editable-layers/-/editable-layers-9.3.7.tgz",
+      "integrity": "sha512-pov+m9jhUVP6nHFXhk7UQO00xfnSqrzcVBPdONHJAm4IuQayFOVAoHd2dZCn0HBL1Hobp9o3N/xlbWyJyhNJag==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/core": "^4.0.0",
+        "@math.gl/web-mercator": ">=4.0.1",
+        "@turf/along": "^7.2.0",
+        "@turf/area": "^7.2.0",
+        "@turf/bbox": "^7.2.0",
+        "@turf/bbox-polygon": "^7.2.0",
+        "@turf/bearing": "^7.2.0",
+        "@turf/boolean-point-in-polygon": "^7.2.0",
+        "@turf/boolean-within": "^7.2.0",
+        "@turf/buffer": "^7.2.0",
+        "@turf/center": "^7.2.0",
+        "@turf/centroid": "^7.2.0",
+        "@turf/circle": "^7.2.0",
+        "@turf/clone": "^7.2.0",
+        "@turf/destination": "^7.2.0",
+        "@turf/difference": "^7.2.0",
+        "@turf/distance": "^7.2.0",
+        "@turf/ellipse": "^7.2.0",
+        "@turf/helpers": "^7.2.0",
+        "@turf/intersect": "^7.2.0",
+        "@turf/invariant": "^7.2.0",
+        "@turf/kinks": "^7.2.0",
+        "@turf/line-intersect": "^7.2.0",
+        "@turf/meta": "^7.2.0",
+        "@turf/midpoint": "^7.2.0",
+        "@turf/nearest-point-on-line": "^7.2.0",
+        "@turf/point-to-line-distance": "^7.2.0",
+        "@turf/polygon-to-line": "^7.2.0",
+        "@turf/rewind": "^7.2.0",
+        "@turf/rhumb-bearing": "^7.2.0",
+        "@turf/rhumb-destination": "^7.2.0",
+        "@turf/rhumb-distance": "^7.2.0",
+        "@turf/transform-rotate": "^7.2.0",
+        "@turf/transform-scale": "^7.2.0",
+        "@turf/transform-translate": "^7.2.0",
+        "@turf/union": "^7.2.0",
+        "@types/geojson": "^7946.0.16",
+        "lodash.throttle": "^4.1.1",
+        "preact": "^10.17.0"
+      },
+      "peerDependencies": {
+        "@deck.gl-community/layers": "~9.3.0",
+        "@deck.gl/core": "~9.3.0",
+        "@deck.gl/extensions": "~9.3.0",
+        "@deck.gl/geo-layers": "~9.3.0",
+        "@deck.gl/layers": "~9.3.0",
+        "@deck.gl/mesh-layers": "~9.3.0",
+        "@luma.gl/constants": "~9.3.2",
+        "@luma.gl/core": "~9.3.2",
+        "@luma.gl/engine": "~9.3.2",
+        "h3-js": "^4.2.1"
+      }
+    },
+    "node_modules/@deck.gl-community/editable-layers/node_modules/@turf/boolean-clockwise": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-7.3.5.tgz",
+      "integrity": "sha512-VpDIpTKBjH4oPbzx1ns18TWcosi+qCRtgU1HIJHLj4NWyLNr7TX86DvomCvZRPfsFxkYYgkFlqHBG1a29dcyqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@deck.gl-community/editable-layers/node_modules/@turf/clone": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.3.5.tgz",
+      "integrity": "sha512-qfIaHj3410QEcTpiCRnTzhq8YrUp2gWrUIPLBAEFykopNxJkq1du1VrRzvuAo36ap2UV7KppkS6wGNypbcxswQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@deck.gl-community/editable-layers/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@deck.gl-community/editable-layers/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@deck.gl-community/editable-layers/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@deck.gl-community/editable-layers/node_modules/@turf/rewind": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-7.3.5.tgz",
+      "integrity": "sha512-4AZdDh55JeCoKWLS5AC6MuXqAvoqSpj2WigtowtA3JIJ/1J4SclRrV6BGq/Xemwm5yKtRePHazBVUmG5uU75og==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-clockwise": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@deck.gl-community/layers": {
+      "version": "9.3.7",
+      "resolved": "https://registry.npmjs.org/@deck.gl-community/layers/-/layers-9.3.7.tgz",
+      "integrity": "sha512-bXtRig0U2u4I1WMtmq4Y8y9Fc4T9GqucqqdBJw5yprW0zH8ZLX25uAMugDdmbbb0GBtRwTQkxCquIn29Zf89Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/textures": "^4.4.1",
+        "@luma.gl/constants": "~9.3.2",
+        "@luma.gl/shadertools": "~9.3.2",
+        "@math.gl/core": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "~9.3.0",
+        "@deck.gl/layers": "~9.3.0",
+        "@deck.gl/mesh-layers": "~9.3.0",
+        "@loaders.gl/core": "^4.4.1",
+        "@luma.gl/core": "~9.3.2",
+        "@luma.gl/engine": "~9.3.2"
       }
     },
     "node_modules/@deck.gl/aggregation-layers": {
@@ -986,6 +1155,12 @@
         "@loaders.gl/core": "~4.4.0"
       }
     },
+    "node_modules/@luma.gl/constants": {
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-9.3.6.tgz",
+      "integrity": "sha512-EIZopGJbaHIpj1smMWfz8/Xok3SnMGGbPo72DXVLs3JzST/w3AMrPMX1YUmWIA/op3Vdt7CxN6ikJWgRkanSVg==",
+      "license": "MIT"
+    },
     "node_modules/@luma.gl/core": {
       "version": "9.3.3",
       "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-9.3.3.tgz",
@@ -1621,6 +1796,204 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@turf/along": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-7.3.5.tgz",
+      "integrity": "sha512-Ee4AHV9j2Bnlm/5nm4ChY7nkwpaaMffSez9nsJ9HcMbzG+GgTkt0F5pn9d02U7YvuWqckM5lfr3kBI+w2uTz+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.5",
+        "@turf/destination": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/along/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/along/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/area": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.3.5.tgz",
+      "integrity": "sha512-sSn80wPT7XfBIDN3vurCPxhk9W4U8ozS/XImSqeLN8qveTICOxzZkhsGDMp0CuncaN+plWut4a2TdNM7mzZB6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/area/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/area/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.5.tgz",
+      "integrity": "sha512-oG1ya/HtBjAIg4TimbWx+nOYPbY0bCvt82Bq8tm6sBw3qqtbOyRSfDz79Sq90TnH7DXJprJ1qnVGKNtZ6jemfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox-polygon": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-7.3.5.tgz",
+      "integrity": "sha512-Cs9Laej8zfSY51kORM9UcbY4Uf/7X3OIZr/LydbrmmARFSpYH/FZsEQjAGi1S1Q0aYbibVqjEUReHN3ZVsV5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox-polygon/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bearing": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-7.3.5.tgz",
+      "integrity": "sha512-/qabIt/IuPsGlE6RukJ0zOirc6afNxoK7fK1WBNVnHuJjeOpSkW+7q1QW5XQGXBMv3odcD0ZgRR+MBiAHduYSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bearing/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bearing/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@turf/boolean-clockwise": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
@@ -1629,6 +2002,281 @@
       "dependencies": {
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.5.tgz",
+      "integrity": "sha512-ba7+B0wzaS9GtERZOoXUZ6oW8IcIJHNQZf3c+tiD9ESjcsPO1Q/4qIJGTKl92nBLhhracHJxMWBM/U6hAVkaRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-in-polygon/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-in-polygon/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-on-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-7.3.5.tgz",
+      "integrity": "sha512-TuWfrAT63W43BDzgYc94UzQ5/PjF1aTnh4AIzmQwez1YnimShYcOTwo8OIHzDaB6gbbvFsfxYMuOA5JOp942Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-on-line/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-on-line/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-within": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-7.3.5.tgz",
+      "integrity": "sha512-FsZhkAoi9KU2F0D5dyOQ38A7y9Bk8XTmUfLKAJa12xHN0QtXZEYH86YdVlrI1XgfFB9gmUddJPFX+bJATy6rxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-split": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-within/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-within/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/buffer": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-7.3.5.tgz",
+      "integrity": "sha512-TGls3nYtWzviKHT00XVBfHKa7Z2oIZKqiHN7R0xErGwMSAR7YhxVROhxq/iyIsWZjl1SlPwweZZIxWILQuxpZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/center": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/jsts": "^2.7.1",
+        "@turf/meta": "7.3.5",
+        "@turf/projection": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "d3-geo": "1.7.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/buffer/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/buffer/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-7.3.5.tgz",
+      "integrity": "sha512-eub5/Kfdmn89ZqwCONHI7astmTDEtN5M6+JfOkgoSyhKKFhUJYNxUyH1F/vCtIP7j1K369Vs4L9TYiuGapvIKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.3.5.tgz",
+      "integrity": "sha512-hkWaqwGFdOn6Tf0EWfn2yn1XZ1FWE1h2C5ZWstDMu/FxYO5DB+YjlmOFPl4K6SmSOEgdV07eK2vDCyPeTHqKGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/circle": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-7.3.5.tgz",
+      "integrity": "sha512-Tse7GJrx0rxaQ5BdY6pHZ9HFPrZwRMry2yaqq94UsUyonhy1m7U2icB3Zp4M8o4XjHIGTCq9i2BYcGJram51Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/destination": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/circle/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/clone": {
@@ -1640,11 +2288,270 @@
         "@turf/helpers": "^5.1.5"
       }
     },
+    "node_modules/@turf/destination": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-7.3.5.tgz",
+      "integrity": "sha512-x6ylChhOlIbucRSw7wF6z2gSEqqQl+dE0nSH5AL/ojZkqqGYahiw+2P4A8ZMuDM6rzH+FIqRYDes0o4nSArZCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/destination/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/destination/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/difference": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-7.3.5.tgz",
+      "integrity": "sha512-iDyWYCvgS3vgB8W1ai2cvfJaTq9bOt1QghiVkCNIyccF97CgtYJzenREVVUlp8qU9lJlbQ/ameyKvXPA1uOAlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/difference/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/difference/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.5.tgz",
+      "integrity": "sha512-uQAC63zg/l91KUxzfhqio7Ii3+UXTrPOVJScIdRj6EO6+9XHI4kC+AdyIS4cPAv14sZfJLIBxzMnzcGrss+kEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/ellipse": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-7.3.5.tgz",
+      "integrity": "sha512-C478LrdvUkjwIVGN6PoYsFp27PuT+W2IH4ZOVt9sd4359hRPFhJ2m+f8jSPfS6rdamdvc/O+h7vNmOIBRP/TeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/destination": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/transform-rotate": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/ellipse/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/ellipse/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/geojson-rbush": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/geojson-rbush/-/geojson-rbush-7.3.5.tgz",
+      "integrity": "sha512-30/hQqc+ErnlcavvDdxGfgm8VtsJDEzSYpf3mPqYxOyI976l49T6+1jCQD5xKswml6o8zZAaTSe6ZcSKF+SCNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/geojson-rbush/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/geojson-rbush/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@turf/helpers": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
       "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw==",
       "license": "MIT"
+    },
+    "node_modules/@turf/intersect": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-7.3.5.tgz",
+      "integrity": "sha512-v11Do9ySbsE08ffiwboQeFKvYByyxzvAz0ls837A9T3rSC+8vKMmK815S+C5v8CBMLNhuBCSgqnOIV3zonNICQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/intersect/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/intersect/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
     },
     "node_modules/@turf/invariant": {
       "version": "5.2.0",
@@ -1655,6 +2562,190 @@
         "@turf/helpers": "^5.1.5"
       }
     },
+    "node_modules/@turf/jsts": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@turf/jsts/-/jsts-2.7.2.tgz",
+      "integrity": "sha512-zAezGlwWHPyU0zxwcX2wQY3RkRpwuoBmhhNE9HY9kWhFDkCxZ3aWK5URKwa/SWKJbj9aztO+8vtdiBA28KVJFg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "dependencies": {
+        "jsts": "2.7.1"
+      }
+    },
+    "node_modules/@turf/kinks": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-7.3.5.tgz",
+      "integrity": "sha512-dPW8d4vs1v8WMobjyq/TVqajjPwkMsl94IF58yp1UYlmJDQrW4iNRUmI9fFzww+fl7epCKNwY+jZhXf1DRi93w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/kinks/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-intersect": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.3.5.tgz",
+      "integrity": "sha512-2Cl4oPsjaDdfIwz/5IRDdG2fNdfp3W6atICm81vnzl/GwURoVP+CLjXJ64QWWzpzIbgX2XprJQTmamByDt5MDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "sweepline-intersections": "^1.5.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-intersect/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-segment": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-7.3.5.tgz",
+      "integrity": "sha512-TM1aCu7utM6fllAEHO8PNqBJZ/uoFJVNp2A0YI7FyWN928hPbacsvNtLeVz/Kq1ZbeqQ1ZIKRxo9FdVjaj8hGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-segment/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-segment/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-segment/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-split": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-7.3.5.tgz",
+      "integrity": "sha512-GEuy+LdbbaqtYjHk/i1G8sK51wfCdPqTO8uH0dJZ6WlcIcZQfRcKKI4ksFm7NkVyfmw8gXWbpMJD8lO380GFBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/geojson-rbush": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/line-segment": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@turf/truncate": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-split/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-split/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-split/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@turf/meta": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
@@ -1662,6 +2753,256 @@
       "license": "MIT",
       "dependencies": {
         "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/midpoint": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-7.3.5.tgz",
+      "integrity": "sha512-y92O2YDDBkZp7jAUuUPgof/HiXHjJSkKjEtQRjWXZcjTlzHd/Fqg6/twarY2wNkENK2EuaaiV9MDy74FeRG2Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.5",
+        "@turf/destination": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/midpoint/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.3.5.tgz",
+      "integrity": "sha512-MZn6OkEFZpjS6BNUANfqiHMIbQSivu7TNji3a+OAIrnPJ71vp8cbz0N2aVEa5M7I8ipvxoxAPIV3eqg3h280Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-7.3.5.tgz",
+      "integrity": "sha512-mR1NAIX+JfpYAJQ9u3gpIV37QzYvBOefDP+/16uBCAOM8Fp12goT8l7WdenT0dvB4wPibbqM2+2kyEl5u9XJog==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@turf/projection": "7.3.5",
+        "@turf/rhumb-bearing": "7.3.5",
+        "@turf/rhumb-distance": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-to-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-7.3.5.tgz",
+      "integrity": "sha512-Mat5tvJcW3grpXCNFcMvjHL3d8hO4eoIgF3qYpXj25BHx/S7SJUOgyCV5x3arC0rCfM/cB71VmNDm9k57ec7bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-to-line/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-to-line/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/projection": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-7.3.5.tgz",
+      "integrity": "sha512-G4bejYKT0vCQZryMhEoS9aLmP7ThDg6nb3zi3wPzELiTrGNOd2YgkWVheQDGCk4hcqEIWZc9fI2alaRSSkkLVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/projection/node_modules/@turf/clone": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.3.5.tgz",
+      "integrity": "sha512-qfIaHj3410QEcTpiCRnTzhq8YrUp2gWrUIPLBAEFykopNxJkq1du1VrRzvuAo36ap2UV7KppkS6wGNypbcxswQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/projection/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/projection/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/rewind": {
@@ -1675,6 +3016,444 @@
         "@turf/helpers": "^5.1.5",
         "@turf/invariant": "^5.1.5",
         "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/rhumb-bearing": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-7.3.5.tgz",
+      "integrity": "sha512-pYjBAuQTND0+6Y+v+zlQ7Y68SGjP4iG8qJ5QKjFRbB/yeorTY3m9yiXIN4lSyno3TPzEgBeNULuo26H6ygDyng==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-bearing/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-bearing/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-destination": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-7.3.5.tgz",
+      "integrity": "sha512-znICdPBtZq5EKh/Qu0TkiMyNhqiYfM2VUlFOWa7iegCWe1E+X7q/f6rlZ5TcmYVyLZ95XZ6eciDNmgVmpHVWaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-destination/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-destination/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-distance": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-7.3.5.tgz",
+      "integrity": "sha512-dBFxmKrjRaAdwc4SCmGyAS2BDPCH35IBNl++Ypd1RB8JR2D3khl3zrTvxrlJ5qoN1WDvyPbvDYCrt2UnTX+8Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-distance/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-distance/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-rotate": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-7.3.5.tgz",
+      "integrity": "sha512-WXkteI0DihwCukZesVXVVYpsoyftYoiBtq1b+u1Dz4HyATK25zfEeWChlgRtApbiePF6uqG7bSQS+K8vjC4c0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/rhumb-bearing": "7.3.5",
+        "@turf/rhumb-destination": "7.3.5",
+        "@turf/rhumb-distance": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-rotate/node_modules/@turf/clone": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.3.5.tgz",
+      "integrity": "sha512-qfIaHj3410QEcTpiCRnTzhq8YrUp2gWrUIPLBAEFykopNxJkq1du1VrRzvuAo36ap2UV7KppkS6wGNypbcxswQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-rotate/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-rotate/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-rotate/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-scale": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-7.3.5.tgz",
+      "integrity": "sha512-eAmey/LtJVT6WlCMULsnd+sCAOwCezG6lVP67qN5HARZ8ft+b7yBiU4FC+IGXbVsrdRcCRLSzoQc6K0fROoo2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/center": "7.3.5",
+        "@turf/centroid": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/rhumb-bearing": "7.3.5",
+        "@turf/rhumb-destination": "7.3.5",
+        "@turf/rhumb-distance": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-scale/node_modules/@turf/clone": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.3.5.tgz",
+      "integrity": "sha512-qfIaHj3410QEcTpiCRnTzhq8YrUp2gWrUIPLBAEFykopNxJkq1du1VrRzvuAo36ap2UV7KppkS6wGNypbcxswQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-scale/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-scale/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-scale/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-translate": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-7.3.5.tgz",
+      "integrity": "sha512-OMQLOFLIjqeDNARaa2kdh1AgvWKFgq41/I6k3CAaj1UcB4javpVFMlcjRJY+pL2oZtMRZRcUZxhO+zSNl6p83Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/rhumb-destination": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-translate/node_modules/@turf/clone": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.3.5.tgz",
+      "integrity": "sha512-qfIaHj3410QEcTpiCRnTzhq8YrUp2gWrUIPLBAEFykopNxJkq1du1VrRzvuAo36ap2UV7KppkS6wGNypbcxswQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-translate/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-translate/node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-translate/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/truncate": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.3.5.tgz",
+      "integrity": "sha512-Qx2iv3KIqKuDAUduMfaJ5fFegEWBeRve5zePalRevS16bMUqEX+jnKPK9fWGyUuPqT61qP1Kybz0PTWPbUbljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/truncate/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/truncate/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/union": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-7.3.5.tgz",
+      "integrity": "sha512-/FSKhl+LX4+M7L/Trmiln0CDPWS8vCneGnQktt1o5XbCY/zIpH1JdxHEBFXhFZg4beAyXCz0uuxRyW9N/DH+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/union/node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/union/node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -2011,6 +3790,15 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/brotli": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
@@ -2169,6 +3957,21 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-geo": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
+      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1"
       }
     },
     "node_modules/d3-hexbin": {
@@ -2495,6 +4298,15 @@
       "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
       "license": "MIT"
     },
+    "node_modules/jsts": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.7.1.tgz",
+      "integrity": "sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/jszip": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -2807,6 +4619,12 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+      "license": "MIT"
+    },
     "node_modules/long": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
@@ -3028,6 +4846,25 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/polyclip-ts": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/polyclip-ts/-/polyclip-ts-0.16.8.tgz",
+      "integrity": "sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.1.0",
+        "splaytree-ts": "^1.0.2"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
@@ -3063,6 +4900,24 @@
       "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
       "license": "ISC"
     },
+    "node_modules/preact": {
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -3079,6 +4934,21 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
+    "node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
+    "node_modules/rbush/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
       "license": "ISC"
     },
     "node_modules/readable-stream": {
@@ -3104,6 +4974,12 @@
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
     },
     "node_modules/rolldown": {
       "version": "1.1.5",
@@ -3180,6 +5056,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/splaytree-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
+      "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
+      "license": "BDS-3-Clause"
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -3244,6 +5126,21 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/sweepline-intersections": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz",
+      "integrity": "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyqueue": "^2.0.0"
+      }
+    },
+    "node_modules/sweepline-intersections/node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
     },
     "node_modules/table-layout": {
       "version": "4.1.1",

--- a/js/package.json
+++ b/js/package.json
@@ -13,6 +13,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@deck.gl-community/editable-layers": "~9.3.7",
+    "@deck.gl-community/layers": "~9.3.7",
     "@deck.gl/aggregation-layers": "~9.3.6",
     "@deck.gl/core": "~9.3.6",
     "@deck.gl/extensions": "~9.3.6",

--- a/js/src/__tests__/drawing-manager.test.js
+++ b/js/src/__tests__/drawing-manager.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACTIVE_DRAWING_MODES,
+  DRAG_DRAW_MODES,
+  deleteFeatures,
+  getCursorForMode,
+  getModeInstance,
+} from "../drawing-manager.js";
+
+describe("getModeInstance", () => {
+  it("resolves every documented mode", () => {
+    for (const mode of [
+      "view", "modify", "translate", "delete",
+      "draw_point", "draw_line", "draw_polygon",
+      "draw_rectangle", "draw_square", "draw_circle",
+    ]) {
+      expect(getModeInstance(mode), mode).toBeTruthy();
+    }
+  });
+
+  it("returns null for unknown modes", () => {
+    expect(getModeInstance("scribble")).toBeNull();
+  });
+});
+
+describe("getCursorForMode", () => {
+  it("crosshair while drawing, pointer for edit/delete, grab otherwise", () => {
+    expect(getCursorForMode("draw_polygon")).toBe("crosshair");
+    expect(getCursorForMode("modify")).toBe("pointer");
+    expect(getCursorForMode("delete")).toBe("pointer");
+    expect(getCursorForMode("view")).toBe("grab");
+  });
+});
+
+describe("mode sets", () => {
+  it("drag-draw modes are a subset of active modes", () => {
+    for (const mode of DRAG_DRAW_MODES) {
+      expect(ACTIVE_DRAWING_MODES.has(mode)).toBe(true);
+    }
+  });
+});
+
+describe("deleteFeatures", () => {
+  const fc = {
+    type: "FeatureCollection",
+    features: [{ id: "a" }, { id: "b" }, { id: "c" }],
+  };
+
+  it("removes features by index without mutating the input", () => {
+    const out = deleteFeatures(fc, [0, 2]);
+    expect(out.features.map((f) => f.id)).toEqual(["b"]);
+    expect(fc.features).toHaveLength(3);
+  });
+
+  it("handles empty index lists", () => {
+    expect(deleteFeatures(fc, []).features).toHaveLength(3);
+  });
+});

--- a/js/src/drawing-manager.js
+++ b/js/src/drawing-manager.js
@@ -1,0 +1,160 @@
+/**
+ * Drawing manager — creates and manages an EditableGeoJsonLayer for
+ * interactive drawing, using @deck.gl-community/editable-layers.
+ *
+ * Ported from deckgl_dash's utils/drawingManager.js; React state setters
+ * are replaced by plain callbacks.
+ */
+
+import {
+  EditableGeoJsonLayer,
+  ViewMode,
+  ModifyMode,
+  TranslateMode,
+  DrawPointMode,
+  DrawLineStringMode,
+  DrawPolygonMode,
+  DrawRectangleMode,
+  DrawSquareMode,
+  DrawCircleFromCenterMode,
+  DeleteMode,
+} from "@deck.gl-community/editable-layers";
+
+/** Map of user-facing mode strings to editable-layers mode instances. */
+const MODE_MAP = {
+  view: new ViewMode(),
+  modify: new ModifyMode(),
+  translate: new TranslateMode(),
+  draw_point: new DrawPointMode(),
+  draw_line: new DrawLineStringMode(),
+  draw_polygon: new DrawPolygonMode(),
+  draw_rectangle: new DrawRectangleMode(),
+  draw_square: new DrawSquareMode(),
+  draw_circle: new DrawCircleFromCenterMode(),
+  delete: new DeleteMode(),
+};
+
+/** Drawing modes that use drag interaction (conflict with map panning). */
+export const DRAG_DRAW_MODES = new Set(["draw_circle", "draw_rectangle", "draw_square"]);
+
+/** All active drawing modes (not view) — used for cursor and doubleClickZoom. */
+export const ACTIVE_DRAWING_MODES = new Set([
+  "draw_point", "draw_line", "draw_polygon",
+  "draw_rectangle", "draw_square", "draw_circle",
+]);
+
+/** Modes where clicking a feature should select it. */
+const SELECTION_MODES = new Set(["modify", "translate"]);
+
+/** Edit types that should sync completed state to Python. */
+const SYNC_EVENTS = new Set([
+  "addFeature", "finishMovePosition", "removePosition", "addPosition", "deleteFeature",
+]);
+
+/** Get the mode instance for a mode string (null when unknown). */
+export function getModeInstance(modeStr) {
+  return MODE_MAP[modeStr] || null;
+}
+
+const DEFAULT_STYLE = {
+  fillColor: [255, 140, 0, 100],
+  lineColor: [0, 0, 0, 255],
+  lineWidth: 2,
+  tentativeFillColor: [255, 140, 0, 50],
+  tentativeLineColor: [255, 140, 0, 200],
+  editHandlePointColor: [255, 0, 0, 255],
+  selectedFillColor: [255, 200, 0, 150],
+  selectedLineColor: [255, 100, 0, 255],
+  pointRadius: 5,
+};
+
+/** CSS cursor for each drawing mode. */
+export function getCursorForMode(modeStr) {
+  if (ACTIVE_DRAWING_MODES.has(modeStr)) return "crosshair";
+  if (SELECTION_MODES.has(modeStr) || modeStr === "delete") return "pointer";
+  return "grab";
+}
+
+/**
+ * Create an EditableGeoJsonLayer for drawing/editing.
+ *
+ * @param {object} drawingConfig - { mode, selectedFeatureIndexes, style }
+ * @param {object} features - Current GeoJSON FeatureCollection
+ * @param {number[]} selectedIndexes - Currently selected feature indexes
+ * @param {object} callbacks - { setFeatures, setSelectedIndexes, syncToModel }
+ * @returns {EditableGeoJsonLayer|null}
+ */
+export function createEditableLayer(drawingConfig, features, selectedIndexes, callbacks) {
+  const { mode: modeStr, style = {} } = drawingConfig;
+  const modeInstance = getModeInstance(modeStr);
+  if (!modeInstance) {
+    console.warn(`Unknown drawing mode: ${modeStr}`);
+    return null;
+  }
+
+  const mergedStyle = { ...DEFAULT_STYLE, ...style };
+  const isSelectionMode = SELECTION_MODES.has(modeStr);
+  const { setFeatures, setSelectedIndexes, syncToModel } = callbacks;
+
+  return new EditableGeoJsonLayer({
+    id: "__drawing-layer",
+    data: features,
+    mode: modeInstance,
+    selectedFeatureIndexes: selectedIndexes,
+
+    // Committed feature styles — highlight selected features differently
+    getFillColor: (feature, { index }) =>
+      selectedIndexes.includes(index) ? mergedStyle.selectedFillColor : mergedStyle.fillColor,
+    getLineColor: (feature, { index }) =>
+      selectedIndexes.includes(index) ? mergedStyle.selectedLineColor : mergedStyle.lineColor,
+    getLineWidth: () => mergedStyle.lineWidth,
+
+    // Point size
+    getRadius: () => mergedStyle.pointRadius,
+    pointRadiusMinPixels: mergedStyle.pointRadius,
+    pointRadiusUnits: "pixels",
+
+    // Tentative (in-progress) feature styles
+    getTentativeFillColor: () => mergedStyle.tentativeFillColor,
+    getTentativeLineColor: () => mergedStyle.tentativeLineColor,
+    getTentativeLineWidth: () => mergedStyle.lineWidth,
+
+    // Edit handle styles
+    getEditHandlePointColor: () => mergedStyle.editHandlePointColor,
+    editHandlePointRadiusScale: 4,
+    editHandlePointRadiusMinPixels: 4,
+
+    // Mode config — controls measurement tooltips
+    modeConfig: mergedStyle.showMeasurements === false
+      ? { formatTooltip: () => null }
+      : {},
+
+    pickable: true,
+    autoHighlight: false,
+
+    // Click handler for selection in modify/translate modes
+    onClick: (info) => {
+      if (isSelectionMode && info.index >= 0) {
+        setSelectedIndexes([info.index]);
+      }
+    },
+
+    onEdit: ({ updatedData, editType }) => {
+      // Always update internal state for responsive UI
+      setFeatures(updatedData);
+      // Sync to Python on meaningful edits
+      if (SYNC_EVENTS.has(editType)) {
+        syncToModel(updatedData, editType);
+      }
+    },
+  });
+}
+
+/** Delete features at the given indexes from a FeatureCollection. */
+export function deleteFeatures(featureCollection, indexes) {
+  const indexSet = new Set(indexes);
+  return {
+    type: "FeatureCollection",
+    features: featureCollection.features.filter((_, i) => !indexSet.has(i)),
+  };
+}

--- a/js/src/drawing.js
+++ b/js/src/drawing.js
@@ -1,0 +1,127 @@
+/**
+ * Drawing controller: owns the feature collection and selection state,
+ * builds the editable layer, syncs edits back to Python, and adjusts map
+ * interactions (cursor, drag-pan, double-click zoom) per mode.
+ *
+ * The anywidget counterpart of deckgl_dash's useDrawing hook.
+ */
+import {
+  ACTIVE_DRAWING_MODES,
+  DRAG_DRAW_MODES,
+  createEditableLayer,
+  deleteFeatures,
+  getCursorForMode,
+} from "./drawing-manager.js";
+
+const EMPTY_FEATURE_COLLECTION = { type: "FeatureCollection", features: [] };
+
+export function createDrawingController({ model, map, onLayersChanged }) {
+  let features = model.get("drawing_features") || EMPTY_FEATURE_COLLECTION;
+  let selectedIndexes = [];
+  let prevMode = null;
+  let selfUpdate = false; // guard: our own model writes echo back as change events
+
+  const cfg = () => model.get("drawing_config") || {};
+  const isActive = () => {
+    const mode = cfg().mode;
+    return Boolean(mode && mode !== "view");
+  };
+
+  function syncToModel(updated, editType) {
+    selfUpdate = true;
+    try {
+      model.set("drawing_features", updated);
+      model.set("drawing_event", {
+        type: editType,
+        featureCount: updated.features.length,
+        timestamp: Date.now(),
+      });
+      model.save_changes();
+    } finally {
+      selfUpdate = false;
+    }
+  }
+
+  function setFeatures(updated) {
+    features = updated;
+    onLayersChanged();
+  }
+
+  function setSelectedIndexes(indexes) {
+    selectedIndexes = indexes;
+    onLayersChanged();
+  }
+
+  /** Adjust map interactions + cursor for the current mode. */
+  function applyInteractions() {
+    const mode = cfg().mode || "view";
+    const active = isActive();
+    if (DRAG_DRAW_MODES.has(mode)) {
+      map.dragPan.disable();
+    } else {
+      map.dragPan.enable();
+    }
+    if (active) {
+      map.doubleClickZoom.disable();
+    } else {
+      map.doubleClickZoom.enable();
+    }
+    map.getCanvas().style.cursor = active ? getCursorForMode(mode) : "";
+  }
+
+  function handleConfigChange() {
+    const config = cfg();
+    // Clear selection when switching modes
+    if (config.mode !== prevMode) {
+      prevMode = config.mode;
+      selectedIndexes = [];
+    }
+    // deleteSelected: act once, then reset the flag Python-side
+    if (config.deleteSelected && selectedIndexes.length > 0) {
+      const updated = deleteFeatures(features, selectedIndexes);
+      features = updated;
+      selectedIndexes = [];
+      syncToModel(updated, "deleteFeature");
+      selfUpdate = true;
+      try {
+        model.set("drawing_config", { ...config, deleteSelected: false });
+        model.save_changes();
+      } finally {
+        selfUpdate = false;
+      }
+    }
+    applyInteractions();
+    onLayersChanged();
+  }
+
+  model.on("change:drawing_config", () => {
+    if (!selfUpdate) handleConfigChange();
+  });
+  // External feature set (e.g. Python clears or seeds features)
+  model.on("change:drawing_features", () => {
+    if (selfUpdate) return;
+    features = model.get("drawing_features") || EMPTY_FEATURE_COLLECTION;
+    selectedIndexes = [];
+    onLayersChanged();
+  });
+
+  // Initialize interactions for a config supplied at construction time
+  if (isActive()) {
+    prevMode = cfg().mode;
+    applyInteractions();
+  }
+
+  return {
+    /** The editable layer to append on top of the deck layers (or null). */
+    getLayer() {
+      if (!isActive()) return null;
+      const config = cfg();
+      return createEditableLayer(
+        config,
+        features,
+        config.selectedFeatureIndexes?.length ? config.selectedFeatureIndexes : selectedIndexes,
+        { setFeatures, setSelectedIndexes, syncToModel },
+      );
+    },
+  };
+}

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -15,6 +15,7 @@ import { createPerfTracker } from "./perf-tracker.js";
 import { attachPickHandlers } from "./pick-events.js";
 import { applyConfigExtras, resolveStyle } from "./maplibre-config.js";
 import { createTimeFilterAnimation } from "./time-filter-animation.js";
+import { createDrawingController } from "./drawing.js";
 
 /**
  * Inject MapLibre CSS into the document if not already present.
@@ -103,10 +104,22 @@ async function render({ model, el }) {
     map.setStyle(resolveStyle(cfg, model.get("basemap_style"), FALLBACK_STYLE));
   });
 
+  // --- Drawing controller (EditableGeoJsonLayer appended on top) ---
+  let refreshOverlay = () => {};
+  const drawing = createDrawingController({
+    model,
+    map,
+    onLayersChanged: () => refreshOverlay(),
+  });
+
   // --- deck.gl Overlay ---
   let currentLayers = buildLayers(model, map);
+  const composeLayers = () => {
+    const drawLayer = drawing.getLayer();
+    return drawLayer ? [...currentLayers, drawLayer] : currentLayers;
+  };
   const overlay = new MapboxOverlay({
-    layers: currentLayers,
+    layers: composeLayers(),
     getTooltip: (info) => {
       if (!info || !info.picked || !info.layer) return null;
       // Binary layers: look up pre-packed tooltip string by feature index
@@ -133,18 +146,22 @@ async function render({ model, el }) {
   const timeAnim = createTimeFilterAnimation({
     model,
     overlay,
-    getBaseLayers: () => currentLayers,
+    getBaseLayers: composeLayers,
   });
   model.on("change:time_filter", () => timeAnim.sync());
   timeAnim.sync();
+
+  refreshOverlay = () => {
+    overlay.setProps({ layers: composeLayers() });
+    timeAnim.reapply();
+  };
 
   // --- Reactivity: layer_specs or binary_data changes ---
   let lastZoomVisibilityKey = "";
   const rebuildLayers = () => {
     lastZoomVisibilityKey = "";  // force re-evaluation against fresh specs
     currentLayers = buildLayers(model, map);
-    overlay.setProps({ layers: currentLayers });
-    timeAnim.reapply(); // fresh layer instances must inherit the filter window
+    refreshOverlay(); // fresh instances must inherit filter window + drawing layer
   };
   model.on("change:layer_specs", rebuildLayers);
   model.on("change:binary_data", rebuildLayers);
@@ -159,8 +176,7 @@ async function render({ model, el }) {
     if (key !== lastZoomVisibilityKey) {
       lastZoomVisibilityKey = key;
       currentLayers = buildLayers(model, map);
-      overlay.setProps({ layers: currentLayers });
-      timeAnim.reapply();
+      refreshOverlay();
     }
   });
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
       - Picking & Events: guides/picking-events.md
       - Zoom-Gated Visibility: guides/zoom-visibility.md
       - Time Filter & Animation: guides/time-filter.md
+      - Drawing & Editing: guides/drawing.md
       - Basemaps: guides/basemaps.md
       - Authenticated Data: guides/authenticated-data.md
   - API Reference:
@@ -50,6 +51,7 @@ nav:
       - Bounds: api/bounds.md
       - MapLibre Composition: api/maplibre.md
       - Time Filter: api/timefilter.md
+      - Drawing: api/drawing.md
   - Internals:
       - Binary Transfer Research: internals/binary-transfer-research.md
   - Troubleshooting: troubleshooting.md

--- a/src/deckgl_marimo/__init__.py
+++ b/src/deckgl_marimo/__init__.py
@@ -9,6 +9,12 @@ from deckgl_marimo._basemaps import Basemaps
 from deckgl_marimo._binary import pack_binary, pack_polygon_binary
 from deckgl_marimo._bounds import compute_bounds
 from deckgl_marimo._color_scale import ColorScale
+from deckgl_marimo._drawing import (
+    DRAWING_MODES,
+    EMPTY_FEATURE_COLLECTION,
+    DrawingConfig,
+    DrawingStyle,
+)
 from deckgl_marimo._timefilter import build_time_filter, compute_time_domain
 from deckgl_marimo._map import Map
 
@@ -52,6 +58,11 @@ __all__ = [
     # Time filter
     "compute_time_domain",
     "build_time_filter",
+    # Drawing
+    "DrawingConfig",
+    "DrawingStyle",
+    "DRAWING_MODES",
+    "EMPTY_FEATURE_COLLECTION",
     # Accessor type aliases
     "Accessor",
     "ColorAccessor",

--- a/src/deckgl_marimo/_drawing.py
+++ b/src/deckgl_marimo/_drawing.py
@@ -1,0 +1,143 @@
+"""Drawing/editing configuration for the Map widget.
+
+Pairs with ``Map(drawing_config=...)`` and the ``drawing_features`` /
+``drawing_event`` traitlets. The frontend renders an
+``EditableGeoJsonLayer`` (@deck.gl-community/editable-layers) on top of
+the regular deck.gl layers; drawn features arrive in Python as GeoJSON.
+
+Ported from deckgl_dash's ``drawing.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from deckgl_marimo._color_scale import _parse_color
+
+DRAWING_MODES = {
+    "draw_line", "draw_polygon", "draw_circle", "draw_rectangle",
+    "draw_square", "draw_point", "view", "modify", "translate", "delete",
+}
+
+EMPTY_FEATURE_COLLECTION: dict[str, Any] = {"type": "FeatureCollection", "features": []}
+
+
+def _normalize_color(value: Any) -> list[int]:
+    """Normalize hex/named/RGB(A) colors to an RGBA list."""
+    if isinstance(value, (list, tuple)):
+        rgba = list(value)
+    else:
+        rgba = _parse_color(value)
+    if len(rgba) == 3:
+        rgba = [*rgba, 255]
+    return [int(c) for c in rgba]
+
+
+class DrawingStyle:
+    """Style overrides for drawn features.
+
+    Parameters
+    ----------
+    fill_color
+        Fill color for completed features (hex, name, RGB, or RGBA).
+    line_color
+        Stroke color for completed features.
+    line_width
+        Stroke width in pixels.
+    tentative_fill_color
+        Fill color for features while being drawn.
+    tentative_line_color
+        Stroke color for features while being drawn.
+    edit_handle_point_color
+        Color of vertex edit handles in modify mode.
+    point_radius
+        Radius of drawn points in pixels.
+    show_measurements
+        Show distance/area tooltips while drawing lines and circles.
+    """
+
+    def __init__(
+        self,
+        *,
+        fill_color: Any = None,
+        line_color: Any = None,
+        line_width: float | None = None,
+        tentative_fill_color: Any = None,
+        tentative_line_color: Any = None,
+        edit_handle_point_color: Any = None,
+        point_radius: float | None = None,
+        show_measurements: bool | None = None,
+    ) -> None:
+        self._props: dict[str, Any] = {}
+        for key, value, is_color in (
+            ("fillColor", fill_color, True),
+            ("lineColor", line_color, True),
+            ("lineWidth", line_width, False),
+            ("tentativeFillColor", tentative_fill_color, True),
+            ("tentativeLineColor", tentative_line_color, True),
+            ("editHandlePointColor", edit_handle_point_color, True),
+            ("pointRadius", point_radius, False),
+            ("showMeasurements", show_measurements, False),
+        ):
+            if value is not None:
+                self._props[key] = _normalize_color(value) if is_color else value
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(self._props)
+
+
+class DrawingConfig:
+    """Configuration for the drawing/editing system.
+
+    Parameters
+    ----------
+    mode
+        One of ``'draw_line'``, ``'draw_polygon'``, ``'draw_circle'``,
+        ``'draw_rectangle'``, ``'draw_square'``, ``'draw_point'``,
+        ``'view'``, ``'modify'``, ``'translate'``, ``'delete'``.
+        In ``'delete'`` mode each click on a feature deletes it.
+    selected_feature_indexes
+        Feature indexes selected for editing (``'modify'``/``'translate'``).
+    style
+        Optional :class:`DrawingStyle` overrides.
+    delete_selected
+        Set True to delete the currently selected feature(s); the
+        frontend resets the flag after acting on it.
+
+    Example
+    -------
+    ::
+
+        m = dgl.Map(drawing_config=dgl.DrawingConfig(
+            mode="draw_polygon",
+            style=dgl.DrawingStyle(fill_color=[255, 140, 0, 100], line_width=2),
+        ))
+        drawn = widget.value.get("drawing_features", {})
+    """
+
+    def __init__(
+        self,
+        mode: str = "view",
+        *,
+        selected_feature_indexes: list[int] | None = None,
+        style: DrawingStyle | None = None,
+        delete_selected: bool = False,
+    ) -> None:
+        if mode not in DRAWING_MODES:
+            raise ValueError(
+                f"Invalid drawing mode {mode!r}. Must be one of: {sorted(DRAWING_MODES)}"
+            )
+        self.mode = mode
+        self.selected_feature_indexes = selected_feature_indexes or []
+        self.style = style
+        self.delete_selected = delete_selected
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {"mode": self.mode}
+        if self.selected_feature_indexes:
+            result["selectedFeatureIndexes"] = self.selected_feature_indexes
+        if self.style:
+            result["style"] = self.style.to_dict()
+        if self.delete_selected:
+            result["deleteSelected"] = True
+        return result

--- a/src/deckgl_marimo/_map.py
+++ b/src/deckgl_marimo/_map.py
@@ -74,6 +74,7 @@ class Map(anywidget.AnyWidget):
     _VALID_KWARGS: ClassVar[frozenset[str]] = frozenset({
         "layers", "basemap", "center", "zoom", "pitch", "bearing",
         "height", "width", "show_perf_metrics", "time_filter",
+        "drawing_config", "drawing_features",
     })
 
     # Layer specifications (list of dicts from BaseLayer.to_spec())
@@ -108,6 +109,13 @@ class Map(anywidget.AnyWidget):
     # every 500 ms — constant traitlet churn an idle map shouldn't pay.
     show_perf_metrics = traitlets.Bool(False).tag(sync=True)
 
+    # Drawing/editing (see deckgl_marimo.DrawingConfig): the config drives an
+    # EditableGeoJsonLayer in the frontend; drawn features sync back as
+    # GeoJSON and drawing_event reports edit types.
+    drawing_config = traitlets.Dict({}).tag(sync=True)
+    drawing_features = traitlets.Dict({"type": "FeatureCollection", "features": []}).tag(sync=True)
+    drawing_event = traitlets.Dict({}).tag(sync=True)
+
     # GPU time-filter animation (see deckgl_marimo.build_time_filter):
     # {domain, window, current, playing, speed, loop, softEdge?, layerIds?}.
     # Playback runs client-side; current_time reports the throttled head.
@@ -138,6 +146,7 @@ class Map(anywidget.AnyWidget):
         width: str = "100%",
         show_perf_metrics: bool = False,
         time_filter: dict[str, Any] | None = None,
+        drawing_config: Any = None,
         _unsafe_props: bool = False,
         **kwargs: Any,
     ) -> None:
@@ -182,6 +191,10 @@ class Map(anywidget.AnyWidget):
             "time_filter": time_filter or {},
             **kwargs,
         }
+        if drawing_config is not None:
+            init_kwargs["drawing_config"] = (
+                drawing_config.to_dict() if hasattr(drawing_config, "to_dict") else drawing_config
+            )
 
         if center is not None:
             init_kwargs["longitude"] = center[0]

--- a/tests/test_drawing.py
+++ b/tests/test_drawing.py
@@ -1,0 +1,96 @@
+"""Tests for the drawing configuration API (#37)."""
+
+import pytest
+
+from deckgl_marimo import (
+    DRAWING_MODES,
+    EMPTY_FEATURE_COLLECTION,
+    DrawingConfig,
+    DrawingStyle,
+    Map,
+)
+
+
+class TestDrawingStyle:
+    def test_color_normalization(self):
+        style = DrawingStyle(
+            fill_color="#ff8c00",
+            line_color="black",
+            tentative_fill_color=[255, 140, 0, 50],
+            line_width=2,
+            point_radius=8,
+            show_measurements=False,
+        )
+        d = style.to_dict()
+        assert d["fillColor"] == [255, 140, 0, 255]
+        assert d["lineColor"] == [0, 0, 0, 255]
+        assert d["tentativeFillColor"] == [255, 140, 0, 50]
+        assert d["lineWidth"] == 2
+        assert d["pointRadius"] == 8
+        assert d["showMeasurements"] is False
+
+    def test_rgb_gets_alpha(self):
+        assert DrawingStyle(line_color=[1, 2, 3]).to_dict()["lineColor"] == [1, 2, 3, 255]
+
+    def test_empty_style(self):
+        assert DrawingStyle().to_dict() == {}
+
+
+class TestDrawingConfig:
+    def test_valid_modes(self):
+        for mode in DRAWING_MODES:
+            assert DrawingConfig(mode).to_dict()["mode"] == mode
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError, match="Invalid drawing mode"):
+            DrawingConfig("scribble")
+
+    def test_full_config(self):
+        cfg = DrawingConfig(
+            "modify",
+            selected_feature_indexes=[0, 2],
+            style=DrawingStyle(fill_color=[1, 2, 3, 4]),
+            delete_selected=True,
+        )
+        d = cfg.to_dict()
+        assert d == {
+            "mode": "modify",
+            "selectedFeatureIndexes": [0, 2],
+            "style": {"fillColor": [1, 2, 3, 4]},
+            "deleteSelected": True,
+        }
+
+    def test_minimal_config_omits_empty_keys(self):
+        assert DrawingConfig("draw_polygon").to_dict() == {"mode": "draw_polygon"}
+
+
+class TestMapDrawing:
+    def test_map_accepts_config_object_and_dict(self):
+        m = Map(drawing_config=DrawingConfig("draw_polygon"))
+        assert m.drawing_config == {"mode": "draw_polygon"}
+        m2 = Map(drawing_config={"mode": "modify"})
+        assert m2.drawing_config == {"mode": "modify"}
+
+    def test_defaults(self):
+        m = Map()
+        assert m.drawing_config == {}
+        assert m.drawing_features == EMPTY_FEATURE_COLLECTION
+        assert m.drawing_event == {}
+
+    def test_features_settable_from_python(self):
+        m = Map()
+        fc = {
+            "type": "FeatureCollection",
+            "features": [{
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [1.0, 2.0]},
+                "properties": {},
+            }],
+        }
+        m.drawing_features = fc
+        assert m.drawing_features["features"][0]["geometry"]["coordinates"] == [1.0, 2.0]
+
+    def test_runtime_mode_switch(self):
+        m = Map(drawing_config=DrawingConfig("draw_polygon"))
+        m.drawing_config = DrawingConfig("delete").to_dict()
+        assert m.drawing_config["mode"] == "delete"


### PR DESCRIPTION
Closes #37.

**Chain position: 20/20 — stacked on #56 (feat/time-filter). Last PR in the review chain.**

## What

Interactive drawing/editing with GeoJSON readback, ported from deckgl_dash and adapted to anywidget:

**Python**
- `DrawingConfig` — 10 modes (`draw_polygon/line/point/circle/rectangle/square`, `modify`, `translate`, `delete` with click-to-delete, `view`), mode validation, `selected_feature_indexes`, `delete_selected`
- `DrawingStyle` — committed/tentative/edit-handle styling; hex/named/RGB colors normalized through the existing ColorScale parser
- `Map`: `drawing_config` (accepts the object or a dict), **bidirectional** `drawing_features` (edits sync to Python; Python can seed or clear), `drawing_event` readback

**JS**
- `@deck.gl-community/editable-layers` + `@deck.gl-community/layers` at **9.3.7, pinned together** (they tilde-pin each other; since community 9.3.2 deck.gl/luma.gl are peerDependencies, which our single esbuild bundle satisfies — one deck.gl copy, no duplicate-module picking bugs)
- `drawing-manager.js`: near-verbatim port — mode registry, default styles, selection highlighting, measurement tooltips, sync-event filtering
- `drawing.js`: the anywidget controller replacing the React hook — feature/selection state, `deleteSelected` handling with Python-side flag reset, cursor + `dragPan`/`doubleClickZoom` interaction management per mode, and self-echo guards so the widget's own model writes don't loop
- The editable layer composes on top of the deck layers and coexists with the time-filter animation (`refreshOverlay` recomposes both; the drawing layer is never a filter target)

**Example & docs**: `examples/18_drawing.py` (mode radio, live GeoJSON readback, clear button); Drawing & Editing guide covering seeding/clearing, selection deletion, and the interaction side-effects (drag-draw disables panning; active modes disable double-click zoom).

## Verification

11 new Python tests (style normalization, mode validation, config serialization, Map traitlet round-trips) — 341 total. 6 new vitest cases (mode registry, cursor mapping, drag⊂active invariant, immutable `deleteFeatures`) — 52 total. ruff/pyright clean; bundle builds with the community packages (+~0.5 MB); docs build strict.

Interactive draw/modify/delete flows need the end-of-chain browser smoke pass — unit tests cover the pure logic, not pointer gestures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MB6bkjREt8tm7UkFjrogki
